### PR TITLE
feat: add configurable chairman and codex install target

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -2,7 +2,7 @@
 
 **[English Version](./README.md)**
 
-> Claude Code가 Codex, Gemini CLI와 회의해서 결론을 내리는 스킬
+> 여러 AI CLI(Codex, Gemini, ...)의 의견을 모으고, 설정 가능한 의장(Chairman)이 종합해 결론을 내리게 하는 스킬
 > [Karpathy의 LLM Council](https://github.com/karpathy/llm-council)에서 영감을 받음
 
 ## LLM Council과의 차이점
@@ -28,7 +28,7 @@ Agent Council은 AI 합의를 수집하기 위한 3단계 프로세스를 구현
 각 에이전트의 응답을 수집하여 포맷된 형태로 표시합니다.
 
 **Stage 3: Chairman Synthesis (의장 종합)**
-Claude가 의장으로서 모든 의견을 종합하여 공통점, 차이점, 컨텍스트를 기반으로 최종 추천을 제시합니다.
+기본값(`role: auto`)에서는 “현재 사용 중인 호스트 에이전트(Claude Code / Codex CLI 등)”가 의장 역할을 하며, 모든 의견을 종합해 최종 추천을 제시합니다. 원하면 `chairman.command`를 설정해 `council.sh` 안에서 Stage 3 종합을 CLI로 직접 실행할 수도 있습니다.
 
 ## 설치
 
@@ -39,6 +39,11 @@ npx github:team-attention/agent-council
 ```
 
 현재 프로젝트 디렉토리에 스킬 파일들이 복사됩니다.
+
+선택사항 (Codex용 레포 스킬로 설치):
+```bash
+npx github:team-attention/agent-council --target codex
+```
 
 ### 방법 B: Claude Code 플러그인으로 설치
 
@@ -74,6 +79,10 @@ gemini --version
 
 ```yaml
 council:
+  chairman:
+    role: "auto" # auto|claude|codex|gemini|...
+    # command: "codex exec" # 선택: council.sh에서 Stage 3 종합까지 실행
+
   members:
     - name: codex
       command: "codex exec"
@@ -118,8 +127,8 @@ Claude에게 council 소집을 요청하면 됩니다:
 ```
 User: "새 대시보드 프로젝트에 React vs Vue 어떨까? council 소집해줘"
 
-Claude:
-1. council.sh 실행하여 Codex와 Gemini 의견 수집
+호스트 에이전트(Claude Code / Codex CLI):
+1. council.sh 실행하여 설정된 멤버(예: Codex, Gemini) 의견 수집
 2. 각 에이전트의 관점 표시
 3. 의장으로서 종합:
    "Council의 의견을 바탕으로, 대시보드의 데이터 시각화 요구사항과

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **[한국어 버전 (Korean)](./README.ko.md)**
 
-> A Claude Code skill that lets Claude discuss with Codex and Gemini CLI to reach conclusions.
+> A skill that gathers opinions from multiple AI CLIs (Codex, Gemini, ...) and lets a configurable Chairman synthesize a conclusion.
 > Inspired by [Karpathy's LLM Council](https://github.com/karpathy/llm-council)
 
 ## Key Difference from LLM Council
@@ -28,7 +28,7 @@ All configured AI agents receive your question simultaneously and respond indepe
 Responses from each agent are collected and displayed to you in a formatted view.
 
 **Stage 3: Chairman Synthesis**
-Claude acts as the Chairman, synthesizing all opinions into a final recommendation based on commonalities, differences, and context.
+Your host agent (Claude Code / Codex CLI / etc.) acts as the Chairman by default (`role: auto`), synthesizing all opinions into a final recommendation. Optionally, you can configure a Chairman CLI command to run synthesis inside `council.sh`.
 
 ## Setup
 
@@ -39,6 +39,11 @@ npx github:team-attention/agent-council
 ```
 
 This copies the skill files to your current project directory.
+
+Optional (Codex repo skill):
+```bash
+npx github:team-attention/agent-council --target codex
+```
 
 ### Option B: Install via Claude Code Plugin
 
@@ -74,6 +79,10 @@ Edit `council.config.yaml` to customize your council:
 
 ```yaml
 council:
+  chairman:
+    role: "auto" # auto|claude|codex|gemini|...
+    # command: "codex exec" # optional: run Stage 3 inside council.sh
+
   members:
     - name: codex
       command: "codex exec"
@@ -118,8 +127,8 @@ Simply ask Claude to summon the council:
 ```
 User: "React vs Vue for a new dashboard project - summon the council"
 
-Claude:
-1. Executes council.sh to collect opinions from Codex and Gemini
+Host agent (Claude Code / Codex CLI):
+1. Executes council.sh to collect opinions from configured members (e.g., Codex, Gemini)
 2. Displays each agent's perspective
 3. Synthesizes as Chairman:
    "Based on the council's input, considering your dashboard's

--- a/council.config.yaml
+++ b/council.config.yaml
@@ -25,11 +25,17 @@ council:
 
   # Chairman configuration (Claude will act as chairman)
   chairman:
-    role: "claude"
+    # role: auto|claude|codex|gemini|...
+    # - auto: infer from host tool (Claude Code => claude, Codex CLI => codex)
+    role: "auto"
     description: "Synthesizes all opinions and provides final recommendation"
+    # Optional: run synthesis inside council.sh via CLI (otherwise the host agent synthesizes)
+    # command: "codex exec"
 
   # Execution settings
   settings:
     parallel: true          # Run agents in parallel
-    timeout: 120            # Timeout in seconds per agent
+    timeout: 120            # (Reserved) Timeout in seconds per agent (not enforced by the script yet)
     show_thinking: true     # Show "Thinking..." status
+    exclude_chairman_from_members: true  # Avoid calling the chairman as a member by default
+    # synthesize: true       # Force Stage 3 synthesis inside council.sh (requires chairman.command or --chairman codex/gemini)

--- a/skills/agent-council/SKILL.md
+++ b/skills/agent-council/SKILL.md
@@ -10,7 +10,7 @@ description: Collect and synthesize opinions from multiple AI Agents. Use when u
 
 ## Overview
 
-Agent Council gathers opinions from multiple AI Agents (Codex, Gemini, etc.) when facing difficult questions or decisions, with Claude acting as Chairman to synthesize the final response.
+Agent Council gathers opinions from multiple AI Agents (Codex, Gemini, etc.) when facing difficult questions or decisions. A configurable Chairman then synthesizes the final response (default: `role: auto`, meaning the host agent you’re using).
 
 ## Trigger Conditions
 
@@ -20,6 +20,7 @@ This skill activates when:
 - "Review this from multiple perspectives"
 - "Ask codex and gemini for their opinions"
 - "council"
+- "$agent-council"
 
 ## 3-Stage Process (LLM Council Method)
 
@@ -30,7 +31,7 @@ Send the same question to each council member to collect initial opinions
 Collect and display each Agent's response to the user
 
 ### Stage 3: Chairman Synthesis
-Claude (Chairman) synthesizes all responses and presents the final opinion
+The Chairman synthesizes all responses and presents the final opinion (usually handled by the host agent; optionally can be executed inside `council.sh` via `chairman.command`)
 
 ## Usage
 
@@ -40,11 +41,11 @@ Claude (Chairman) synthesizes all responses and presents the final opinion
 ./skills/agent-council/scripts/council.sh "your question here"
 ```
 
-### Execution via Claude
+### Execution via Host Agent
 
-1. Request council summon from Claude
-2. Claude executes the script to collect each Agent's opinion
-3. Claude synthesizes as Chairman and presents final recommendation
+1. Request council summon from your host agent (Claude Code / Codex CLI)
+2. The host agent executes the script to collect each Agent's opinion
+3. The host agent synthesizes as Chairman and presents the final recommendation
 
 ## Examples
 
@@ -53,8 +54,8 @@ Claude (Chairman) synthesizes all responses and presents the final opinion
 ```
 User: "React vs Vue - which fits this project better? Summon the council"
 
-Claude:
-1. Execute council.sh to collect Codex, Gemini opinions
+Host agent:
+1. Execute council.sh to collect opinions from configured members (e.g., Codex, Gemini)
 2. Organize each Agent's perspective
 3. Recommend based on project context
 ```
@@ -64,7 +65,7 @@ Claude:
 ```
 User: "Let's hear other AIs' opinions on this design"
 
-Claude:
+Host agent:
 1. Summarize current design and query the council
 2. Collect feedback from each Agent
 3. Analyze commonalities/differences and provide synthesis
@@ -78,7 +79,7 @@ Council members are configured in `council.config.yaml`. Default members:
 |-------|-------------|-----------------|
 | OpenAI Codex | `codex exec` | Code-focused, pragmatic approach |
 | Google Gemini | `gemini` | Broad knowledge, diverse perspectives |
-| Claude (Chairman) | - | Synthesis and final judgment |
+| Chairman (auto) | - | Synthesis and final judgment (by your host agent) |
 
 ## Requirements
 
@@ -98,6 +99,8 @@ Edit `council.config.yaml` to customize council members:
 
 ```yaml
 council:
+  chairman:
+    role: "auto"
   members:
     - name: codex
       command: "codex exec"
@@ -120,6 +123,6 @@ skills/agent-council/
 
 ## Notes
 
-- API costs incurred for each Agent call
+- Costs and auth depend on each Agent CLI
 - Response time depends on the slowest Agent
 - Do not share sensitive information with the council

--- a/skills/agent-council/scripts/council.sh
+++ b/skills/agent-council/scripts/council.sh
@@ -228,8 +228,12 @@ parse_chairman_command() {
     /^  [a-z]/ && in_chair { in_chair=0 }
     in_chair && /^    command:/ {
         cmd=$0
-        sub(/.*command: *"?/, "", cmd)
-        sub(/".*$/, "", cmd)
+        sub(/.*command:[ \t]*/, "", cmd) # remove prefix
+        sub(/[ \t]*#.*/, "", cmd) # remove comment
+        sub(/[ \t]*$/, "", cmd) # trim trailing space
+        if (substr(cmd, 1, 1) == "\"" && substr(cmd, length(cmd), 1) == "\"") {
+            cmd = substr(cmd, 2, length(cmd)-2)
+        }
         print cmd
         exit
     }

--- a/skills/agent-council/scripts/council.sh
+++ b/skills/agent-council/scripts/council.sh
@@ -161,6 +161,7 @@ fi
 
 PROMPT="${PROMPT_ARGS[*]}"
 TEMP_DIR=$(mktemp -d)
+trap "rm -rf '$TEMP_DIR'" EXIT
 
 # Parse YAML config (simple parser for our structure - macOS compatible)
 parse_members() {

--- a/skills/agent-council/scripts/council.sh
+++ b/skills/agent-council/scripts/council.sh
@@ -362,10 +362,10 @@ call_chairman() {
 
     # Most CLIs accept a prompt arg; codex exec also supports stdin via "-" but we keep it generic here.
     # Read the prompt file into a variable so we can reuse the same execution pattern as members.
-    local SAVED_PROMPT="$PROMPT"
-    PROMPT="$(cat "$prompt_file")"
-    eval "$command \"\$PROMPT\"" 2>/dev/null > "$output_file" || echo "Error calling chairman ($name)" > "$output_file"
-    PROMPT="$SAVED_PROMPT"
+    # Read the prompt file into a local variable to avoid modifying the global PROMPT variable.
+    local chairman_prompt_for_eval
+    chairman_prompt_for_eval="$(cat "$prompt_file")"
+    eval "$command \"\$chairman_prompt_for_eval\"" 2>/dev/null > "$output_file" || echo "Error calling chairman ($name)" > "$output_file"
 }
 
 # Resolve chairman + settings

--- a/skills/agent-council/scripts/council.sh
+++ b/skills/agent-council/scripts/council.sh
@@ -2,12 +2,23 @@
 #
 # Agent Council - Collect opinions from multiple AI Agents
 #
-# Usage: council.sh "question or prompt"
+# Usage:
+#   council.sh [options] "question or prompt"
+#
+# Options:
+#   -c, --config <path>           Use a specific config file path
+#       --chairman <role|auto>    Set chairman role (auto|claude|codex|gemini|...)
+#       --chairman-command <cmd>  Run Stage 3 synthesis via this CLI command
+#       --synthesize              Force Stage 3 synthesis (requires chairman command or inferrable)
+#       --no-synthesize           Disable Stage 3 synthesis (default when no chairman command)
+#       --include-chairman        Do not filter chairman out of members
+#       --exclude-chairman        Filter chairman out of members (default)
+#   -h, --help                    Show help
 #
 # LLM Council (Karpathy) concept:
 # - Stage 1: Send same question to each Agent
 # - Stage 2: Collect and output responses
-# - Stage 3: Claude synthesizes as Chairman (handled externally)
+# - Stage 3: Chairman synthesizes (optional; can be external or via CLI)
 #
 
 set -e
@@ -15,7 +26,20 @@ set -e
 # Get script directory and find config
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-CONFIG_FILE="$SKILL_DIR/council.config.yaml"
+SKILL_CONFIG_FILE="$SKILL_DIR/council.config.yaml"
+REPO_CONFIG_FILE="$(cd "$SKILL_DIR/../.." && pwd)/council.config.yaml"
+
+resolve_default_config_file() {
+    if [ -f "$SKILL_CONFIG_FILE" ]; then
+        echo "$SKILL_CONFIG_FILE"
+    elif [ -f "$REPO_CONFIG_FILE" ]; then
+        echo "$REPO_CONFIG_FILE"
+    else
+        echo "$SKILL_CONFIG_FILE"
+    fi
+}
+
+DEFAULT_CONFIG_FILE="$(resolve_default_config_file)"
 
 # Colors
 RED='\033[0;31m'
@@ -25,6 +49,30 @@ YELLOW='\033[1;33m'
 CYAN='\033[0;36m'
 MAGENTA='\033[0;35m'
 NC='\033[0m' # No Color
+
+usage() {
+    cat <<EOF
+Agent Council - Collect opinions from multiple AI Agents
+
+Usage:
+  $(basename "$0") [options] "question or prompt"
+
+Options:
+  -c, --config <path>           Use a specific config file path
+      --chairman <role|auto>    Set chairman role (auto|claude|codex|gemini|...)
+      --chairman-command <cmd>  Run Stage 3 synthesis via this CLI command
+      --synthesize              Force Stage 3 synthesis (requires chairman command or inferrable)
+      --no-synthesize           Disable Stage 3 synthesis
+      --include-chairman        Do not filter chairman out of members
+      --exclude-chairman        Filter chairman out of members (default)
+  -h, --help                    Show help
+
+Environment overrides:
+  COUNCIL_CONFIG                Same as --config
+  COUNCIL_CHAIRMAN              Same as --chairman
+  COUNCIL_CHAIRMAN_COMMAND      Same as --chairman-command
+EOF
+}
 
 # Color name to code mapping
 get_color_code() {
@@ -39,14 +87,79 @@ get_color_code() {
     esac
 }
 
-# Check arguments
-if [ -z "$1" ]; then
-    echo -e "${RED}Error: Please provide a prompt${NC}"
-    echo "Usage: $0 \"question or prompt\""
+detect_host() {
+    case "$SKILL_DIR" in
+        */.claude/skills/*) echo "claude" ;;
+        */.codex/skills/*) echo "codex" ;;
+        *) echo "unknown" ;;
+    esac
+}
+
+CONFIG_FILE="${COUNCIL_CONFIG:-$DEFAULT_CONFIG_FILE}"
+CHAIRMAN_OVERRIDE="${COUNCIL_CHAIRMAN:-}"
+CHAIRMAN_COMMAND_OVERRIDE="${COUNCIL_CHAIRMAN_COMMAND:-}"
+SYNTHESIZE_OVERRIDE=""
+EXCLUDE_CHAIRMAN_OVERRIDE=""
+
+PROMPT_ARGS=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -c|--config)
+            CONFIG_FILE="$2"
+            shift 2
+            ;;
+        --chairman)
+            CHAIRMAN_OVERRIDE="$2"
+            shift 2
+            ;;
+        --chairman-command)
+            CHAIRMAN_COMMAND_OVERRIDE="$2"
+            shift 2
+            ;;
+        --synthesize)
+            SYNTHESIZE_OVERRIDE="true"
+            shift
+            ;;
+        --no-synthesize)
+            SYNTHESIZE_OVERRIDE="false"
+            shift
+            ;;
+        --include-chairman)
+            EXCLUDE_CHAIRMAN_OVERRIDE="false"
+            shift
+            ;;
+        --exclude-chairman)
+            EXCLUDE_CHAIRMAN_OVERRIDE="true"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            PROMPT_ARGS+=("$@")
+            break
+            ;;
+        -*)
+            echo -e "${RED}Error: Unknown option: $1${NC}" >&2
+            usage >&2
+            exit 2
+            ;;
+        *)
+            PROMPT_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if [ ${#PROMPT_ARGS[@]} -eq 0 ]; then
+    echo -e "${RED}Error: Please provide a prompt${NC}" >&2
+    usage >&2
     exit 1
 fi
 
-PROMPT="$1"
+PROMPT="${PROMPT_ARGS[*]}"
 TEMP_DIR=$(mktemp -d)
 
 # Parse YAML config (simple parser for our structure - macOS compatible)
@@ -87,6 +200,104 @@ parse_members() {
     ' "$CONFIG_FILE"
 }
 
+parse_chairman_role() {
+    if [ ! -f "$CONFIG_FILE" ]; then
+        echo "auto"
+        return
+    fi
+
+    awk '
+    /^  chairman:/ { in_chair=1; next }
+    /^  [a-z]/ && in_chair { in_chair=0 }
+    in_chair && /^    (role|name):/ {
+        val=$2
+        gsub(/"/, "", val)
+        print val
+        exit
+    }
+    ' "$CONFIG_FILE"
+}
+
+parse_chairman_command() {
+    if [ ! -f "$CONFIG_FILE" ]; then
+        return
+    fi
+
+    awk '
+    /^  chairman:/ { in_chair=1; next }
+    /^  [a-z]/ && in_chair { in_chair=0 }
+    in_chair && /^    command:/ {
+        cmd=$0
+        sub(/.*command: *"?/, "", cmd)
+        sub(/".*$/, "", cmd)
+        print cmd
+        exit
+    }
+    ' "$CONFIG_FILE"
+}
+
+parse_setting_bool() {
+    local key="$1"
+    local default="$2"
+
+    if [ ! -f "$CONFIG_FILE" ]; then
+        echo "$default"
+        return
+    fi
+
+    local value
+    value="$(
+        awk -v k="$key" '
+        /^  settings:/ { in_settings=1; next }
+        /^  [a-z]/ && in_settings { in_settings=0 }
+        in_settings && $1 == (k ":") {
+            val=$2
+            gsub(/"/, "", val)
+            print val
+            exit
+        }
+        ' "$CONFIG_FILE"
+    )"
+
+    if [ -z "$value" ]; then
+        echo "$default"
+    else
+        echo "$value"
+    fi
+}
+
+normalize_bool() {
+    case "$(echo "$1" | tr '[:upper:]' '[:lower:]')" in
+        1|true|yes|y|on) echo "true" ;;
+        0|false|no|n|off) echo "false" ;;
+        *) echo "" ;;
+    esac
+}
+
+resolve_auto_role() {
+    local role="$1"
+    local host="$2"
+    local role_lc
+    role_lc="$(echo "$role" | tr '[:upper:]' '[:lower:]')"
+    if [ "$role_lc" != "auto" ] && [ -n "$role_lc" ]; then
+        echo "$role_lc"
+        return
+    fi
+    case "$host" in
+        codex) echo "codex" ;;
+        claude) echo "claude" ;;
+        *) echo "claude" ;;
+    esac
+}
+
+infer_default_chairman_command() {
+    case "$1" in
+        codex) echo "codex exec" ;;
+        gemini) echo "gemini" ;;
+        *) echo "" ;;
+    esac
+}
+
 echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo -e "${CYAN}🏛️  Agent Council - Gathering Opinions${NC}"
 echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
@@ -100,8 +311,11 @@ call_agent() {
     local command="$2"
     local output_file="$TEMP_DIR/${name}.txt"
     local color_code="$3"
+    local show_thinking="$4"
 
-    echo -e "${color_code}[$name]${NC} Thinking..." >&2
+    if [ "$show_thinking" = "true" ]; then
+        echo -e "${color_code}[$name]${NC} Thinking..." >&2
+    fi
 
     # Extract the base command (first word)
     local base_cmd=$(echo "$command" | awk '{print $1}')
@@ -113,8 +327,81 @@ call_agent() {
         echo "$name CLI not installed (command: $base_cmd)" > "$output_file"
     fi
 
-    echo -e "${GREEN}[$name]${NC} Done" >&2
+    if [ "$show_thinking" = "true" ]; then
+        echo -e "${GREEN}[$name]${NC} Done" >&2
+    fi
 }
+
+# Function to call chairman for synthesis
+call_chairman() {
+    local name="$1"
+    local command="$2"
+    local chairman_prompt="$3"
+    local output_file="$TEMP_DIR/__chairman.txt"
+
+    if [ -z "$command" ]; then
+        echo "Chairman command not configured" > "$output_file"
+        return
+    fi
+
+    local base_cmd
+    base_cmd=$(echo "$command" | awk '{print $1}')
+    if ! command -v "$base_cmd" &> /dev/null; then
+        echo "Chairman CLI not installed (command: $base_cmd)" > "$output_file"
+        return
+    fi
+
+    # Use a temp file to avoid shell quoting issues with long/multiline prompts
+    local prompt_file="$TEMP_DIR/__chairman_prompt.txt"
+    printf "%s" "$chairman_prompt" > "$prompt_file"
+
+    # Most CLIs accept a prompt arg; codex exec also supports stdin via "-" but we keep it generic here.
+    # Read the prompt file into a variable so we can reuse the same execution pattern as members.
+    local SAVED_PROMPT="$PROMPT"
+    PROMPT="$(cat "$prompt_file")"
+    eval "$command \"\$PROMPT\"" 2>/dev/null > "$output_file" || echo "Error calling chairman ($name)" > "$output_file"
+    PROMPT="$SAVED_PROMPT"
+}
+
+# Resolve chairman + settings
+HOST="$(detect_host)"
+CHAIRMAN_ROLE_RAW="${CHAIRMAN_OVERRIDE:-$(parse_chairman_role)}"
+CHAIRMAN_ROLE="$(resolve_auto_role "${CHAIRMAN_ROLE_RAW:-auto}" "$HOST")"
+CHAIRMAN_COMMAND="${CHAIRMAN_COMMAND_OVERRIDE:-$(parse_chairman_command)}"
+
+EXCLUDE_CHAIRMAN_FROM_MEMBERS_RAW="${EXCLUDE_CHAIRMAN_OVERRIDE:-$(parse_setting_bool "exclude_chairman_from_members" "true")}"
+EXCLUDE_CHAIRMAN_FROM_MEMBERS="$(normalize_bool "$EXCLUDE_CHAIRMAN_FROM_MEMBERS_RAW")"
+if [ -z "$EXCLUDE_CHAIRMAN_FROM_MEMBERS" ]; then
+    EXCLUDE_CHAIRMAN_FROM_MEMBERS="true"
+fi
+
+SHOW_THINKING_RAW="$(parse_setting_bool "show_thinking" "true")"
+SHOW_THINKING="$(normalize_bool "$SHOW_THINKING_RAW")"
+if [ -z "$SHOW_THINKING" ]; then
+    SHOW_THINKING="true"
+fi
+
+PARALLEL_RAW="$(parse_setting_bool "parallel" "true")"
+PARALLEL="$(normalize_bool "$PARALLEL_RAW")"
+if [ -z "$PARALLEL" ]; then
+    PARALLEL="true"
+fi
+
+SYNTHESIZE_SETTING_RAW="$(parse_setting_bool "synthesize" "")"
+SYNTHESIZE_SETTING="$(normalize_bool "$SYNTHESIZE_SETTING_RAW")"
+if [ -n "$SYNTHESIZE_OVERRIDE" ]; then
+    SYNTHESIZE="$SYNTHESIZE_OVERRIDE"
+elif [ -n "$SYNTHESIZE_SETTING" ]; then
+    SYNTHESIZE="$SYNTHESIZE_SETTING"
+elif [ -n "$CHAIRMAN_COMMAND" ]; then
+    SYNTHESIZE="true"
+else
+    SYNTHESIZE="false"
+fi
+
+if [ "$SYNTHESIZE" = "true" ] && [ -z "$CHAIRMAN_COMMAND" ]; then
+    CHAIRMAN_COMMAND="$(infer_default_chairman_command "$CHAIRMAN_ROLE")"
+fi
 
 # Stage 1: Collect members and call in parallel
 echo -e "${YELLOW}Stage 1: Collecting opinions from council members...${NC}"
@@ -123,21 +410,36 @@ echo ""
 # Read members and start parallel calls
 declare -a PIDS
 declare -a MEMBERS
+declare -a SKIPPED
 
 while IFS='|' read -r name cmd emoji color; do
     [ -z "$name" ] && continue
+    if [ "$EXCLUDE_CHAIRMAN_FROM_MEMBERS" = "true" ] && [ "$(echo "$name" | tr '[:upper:]' '[:lower:]')" = "$CHAIRMAN_ROLE" ]; then
+        SKIPPED+=("$name")
+        continue
+    fi
     MEMBERS+=("$name|$emoji|$color")
     color_code=$(get_color_code "$color")
-    call_agent "$name" "$cmd" "$color_code" &
-    PIDS+=($!)
+    if [ "$PARALLEL" = "true" ]; then
+        call_agent "$name" "$cmd" "$color_code" "$SHOW_THINKING" &
+        PIDS+=($!)
+    else
+        call_agent "$name" "$cmd" "$color_code" "$SHOW_THINKING"
+    fi
 done < <(parse_members)
 
 # Wait for all agents
-for pid in "${PIDS[@]}"; do
-    wait "$pid" 2>/dev/null || true
-done
+if [ "$PARALLEL" = "true" ]; then
+    for pid in "${PIDS[@]}"; do
+        wait "$pid" 2>/dev/null || true
+    done
+fi
 
 echo ""
+if [ ${#SKIPPED[@]} -gt 0 ]; then
+    echo -e "${YELLOW}ⓘ Skipped member(s) because they are set as Chairman:${NC} ${SKIPPED[*]}"
+    echo ""
+fi
 echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo -e "${CYAN}Stage 2: Council Opinions${NC}"
 echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
@@ -162,8 +464,47 @@ for member_info in "${MEMBERS[@]}"; do
 done
 
 echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-echo -e "${CYAN}Stage 3: Claude (Chairman) will synthesize above opinions${NC}"
-echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+if [ "$SYNTHESIZE" = "true" ] && [ -n "$CHAIRMAN_COMMAND" ]; then
+    echo -e "${CYAN}Stage 3: Chairman Synthesis (via CLI)${NC}"
+    echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+
+    CHAIRMAN_PROMPT="You are the Chairman of an AI council."
+    CHAIRMAN_PROMPT+=$'\n\n'"User question:"
+    CHAIRMAN_PROMPT+=$'\n'"$PROMPT"
+    CHAIRMAN_PROMPT+=$'\n\n'"Council member opinions:"
+    for member_info in "${MEMBERS[@]}"; do
+        IFS='|' read -r name emoji color <<< "$member_info"
+        output_file="$TEMP_DIR/${name}.txt"
+        CHAIRMAN_PROMPT+=$'\n\n'"[${name}]"
+        if [ -f "$output_file" ]; then
+            CHAIRMAN_PROMPT+=$'\n'"$(cat "$output_file")"
+        else
+            CHAIRMAN_PROMPT+=$'\n'"No response"
+        fi
+    done
+    CHAIRMAN_PROMPT+=$'\n\n'"Please synthesize a final recommendation by:"
+    CHAIRMAN_PROMPT+=$'\n'"- Calling out common ground and disagreements"
+    CHAIRMAN_PROMPT+=$'\n'"- Providing a clear final answer"
+    CHAIRMAN_PROMPT+=$'\n'"- Responding in the same language as the user question"
+
+    call_chairman "$CHAIRMAN_ROLE" "$CHAIRMAN_COMMAND" "$CHAIRMAN_PROMPT"
+
+    output_file="$TEMP_DIR/__chairman.txt"
+    color_code=$(get_color_code "YELLOW")
+    echo -e "${color_code}┌─────────────────────────────────────────────────────────┐${NC}"
+    echo -e "${color_code}│ 🪑 chairman (${CHAIRMAN_ROLE})${NC}"
+    echo -e "${color_code}└─────────────────────────────────────────────────────────┘${NC}"
+    if [ -f "$output_file" ]; then
+        cat "$output_file"
+    else
+        echo "No response"
+    fi
+    echo ""
+else
+    echo -e "${CYAN}Stage 3: ${CHAIRMAN_ROLE} (Chairman) will synthesize above opinions (external)${NC}"
+    echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+fi
 
 # Cleanup
 rm -rf "$TEMP_DIR"


### PR DESCRIPTION
This pull request introduces significant improvements to the Agent Council skill, focusing on making the Chairman (synthesizer) role configurable and enhancing both documentation and script usability. The changes clarify that the host agent (Claude Code, Codex CLI, etc.) acts as the Chairman by default, but this can now be customized via config or CLI options. The documentation and usage instructions are updated in both English and Korean, and the `council.sh` script is refactored to support new options for configuring the Chairman and synthesis process.

Key changes:

**Configurable Chairman Role & Synthesis Process**
- Added support for specifying the Chairman role (`auto`, `claude`, `codex`, `gemini`, etc.) and an optional CLI command for synthesis in both `council.config.yaml` and the `council.sh` script. The script now infers the Chairman from the host agent by default, but this can be overridden via config or command-line arguments. [[1]](diffhunk://#diff-7e4704eca8b49c8debfb0b852283f1462733dd791f7ba441cb2050295750d509L28-R41) [[2]](diffhunk://#diff-d84b880a880097deba7119d73b6e9ecd2708226c1c254d3e943e84a57b05cd65L5-R42) [[3]](diffhunk://#diff-d84b880a880097deba7119d73b6e9ecd2708226c1c254d3e943e84a57b05cd65R53-R76) [[4]](diffhunk://#diff-d84b880a880097deba7119d73b6e9ecd2708226c1c254d3e943e84a57b05cd65L42-R162) [[5]](diffhunk://#diff-d84b880a880097deba7119d73b6e9ecd2708226c1c254d3e943e84a57b05cd65R203-R300)
- Introduced options to force or disable Stage 3 synthesis, and to include or exclude the Chairman from the list of members, with sensible defaults and environment variable overrides. [[1]](diffhunk://#diff-d84b880a880097deba7119d73b6e9ecd2708226c1c254d3e943e84a57b05cd65L5-R42) [[2]](diffhunk://#diff-d84b880a880097deba7119d73b6e9ecd2708226c1c254d3e943e84a57b05cd65R53-R76) [[3]](diffhunk://#diff-d84b880a880097deba7119d73b6e9ecd2708226c1c254d3e943e84a57b05cd65L42-R162)

**Improved Documentation (English and Korean)**
- Updated `README.md`, `README.ko.md`, and `SKILL.md` to clearly explain the new Chairman configuration, default behaviors, and how to customize the council process. This includes new usage examples, YAML config snippets, and clarifications about the host agent's role. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R31) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R43-R47) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R82-R85) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L121-R131) [[6]](diffhunk://#diff-86fa6921bcebf260d55d8a3742c1b513bd78f4ea18366db989b5a03c68c563aeL5-R5) [[7]](diffhunk://#diff-86fa6921bcebf260d55d8a3742c1b513bd78f4ea18366db989b5a03c68c563aeL31-R31) [[8]](diffhunk://#diff-86fa6921bcebf260d55d8a3742c1b513bd78f4ea18366db989b5a03c68c563aeR43-R47) [[9]](diffhunk://#diff-86fa6921bcebf260d55d8a3742c1b513bd78f4ea18366db989b5a03c68c563aeR82-R85) [[10]](diffhunk://#diff-86fa6921bcebf260d55d8a3742c1b513bd78f4ea18366db989b5a03c68c563aeL121-R131) [[11]](diffhunk://#diff-5b8a953cfb9a5fcaf38e979d1113d2a0897c1617c9d5a792b891fefeba8afab6L13-R13) [[12]](diffhunk://#diff-5b8a953cfb9a5fcaf38e979d1113d2a0897c1617c9d5a792b891fefeba8afab6R23) [[13]](diffhunk://#diff-5b8a953cfb9a5fcaf38e979d1113d2a0897c1617c9d5a792b891fefeba8afab6L33-R34) [[14]](diffhunk://#diff-5b8a953cfb9a5fcaf38e979d1113d2a0897c1617c9d5a792b891fefeba8afab6L43-R48) [[15]](diffhunk://#diff-5b8a953cfb9a5fcaf38e979d1113d2a0897c1617c9d5a792b891fefeba8afab6L56-R58) [[16]](diffhunk://#diff-5b8a953cfb9a5fcaf38e979d1113d2a0897c1617c9d5a792b891fefeba8afab6L67-R68) [[17]](diffhunk://#diff-5b8a953cfb9a5fcaf38e979d1113d2a0897c1617c9d5a792b891fefeba8afab6L81-R82) [[18]](diffhunk://#diff-5b8a953cfb9a5fcaf38e979d1113d2a0897c1617c9d5a792b891fefeba8afab6R102-R103) [[19]](diffhunk://#diff-5b8a953cfb9a5fcaf38e979d1113d2a0897c1617c9d5a792b891fefeba8afab6L123-R126)

**Script Usability & CLI Enhancements**
- Refactored `council.sh` to support new CLI options for config file selection, Chairman role/command, synthesis toggling, and member filtering. Added a comprehensive usage/help message and support for environment variable overrides. [[1]](diffhunk://#diff-d84b880a880097deba7119d73b6e9ecd2708226c1c254d3e943e84a57b05cd65L5-R42) [[2]](diffhunk://#diff-d84b880a880097deba7119d73b6e9ecd2708226c1c254d3e943e84a57b05cd65R53-R76) [[3]](diffhunk://#diff-d84b880a880097deba7119d73b6e9ecd2708226c1c254d3e943e84a57b05cd65L42-R162)
- Improved YAML parsing functions to extract Chairman and settings information robustly from the config file.
- Enhanced prompt handling to support multi-word questions and error messages for missing prompts.

**Default Behavior and Safety**
- Ensured that the Chairman is excluded from the members list by default (to avoid duplicate synthesis), but this can be overridden. [[1]](diffhunk://#diff-7e4704eca8b49c8debfb0b852283f1462733dd791f7ba441cb2050295750d509L28-R41) [[2]](diffhunk://#diff-d84b880a880097deba7119d73b6e9ecd2708226c1c254d3e943e84a57b05cd65L5-R42)
- Added notes in documentation about costs, authentication, and security considerations for multi-agent calls.

**Minor Improvements**
- Added new trigger phrase (`$agent-council`) for skill activation.
- Clarified and updated example council member tables and usage flows in documentation. [[1]](diffhunk://#diff-5b8a953cfb9a5fcaf38e979d1113d2a0897c1617c9d5a792b891fefeba8afab6L81-R82) [[2]](diffhunk://#diff-5b8a953cfb9a5fcaf38e979d1113d2a0897c1617c9d5a792b891fefeba8afab6R102-R103)

These changes make the Agent Council skill more flexible, user-friendly, and better documented for both English and Korean users.