### PR TITLE
Feat/council todo UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .DS_Store
+skills/agent-council/.jobs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Project Instructions (Codex)
+
+## Plan / To-do UI (IMPORTANT)
+
+- When you decide to use any Skill, **always** call `update_plan` immediately (before any potentially long-running shell/tool calls) so Codex’s Plan/To-do panel appears. Include **exactly one** `in_progress` item in that first plan.
+- Keep the plan updated during execution (at most one `in_progress` step at a time).
+- For `agent-council`: after the first `council.sh wait` (the non-blocking one), feed `.ui.codex.update_plan.plan` into `update_plan` right away, then repeat `wait → update_plan` until done.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# Project Instructions (Claude Code)
+
+## Todo UI (IMPORTANT)
+
+- When you decide to use any Skill, **always** call `TodoWrite` immediately (before any potentially long-running shell/tool calls) so Claude’s Todo UI appears. Include **exactly one** `in_progress` item in that first todo list.
+- Keep the todo list updated during execution (at most one `in_progress` item at a time).
+- For `agent-council`: after the first `council.sh wait` (the non-blocking one), feed `.ui.claude.todo_write.todos` into `TodoWrite` right away, then repeat `wait → TodoWrite` until done.
+

--- a/README.ko.md
+++ b/README.ko.md
@@ -142,6 +142,17 @@ council:
 .codex/skills/agent-council/scripts/council.sh "질문 내용"
 ```
 
+### 진행상태 표시 (Job Mode)
+
+호스트 UI에서 긴 `council.sh` 실행이 “실시간으로 갱신되는 느낌”이 약하다면, Job Mode를 쓰면 됩니다. 멤버 실행을 백그라운드에서 병렬로 돌리고, 짧은 명령으로 진행상태를 폴링할 수 있어 TODO/plan 업데이트에 유리합니다.
+
+```bash
+JOB_DIR=$(.codex/skills/agent-council/scripts/council-job.sh start "질문 내용")
+.codex/skills/agent-council/scripts/council-job.sh status --text "$JOB_DIR"
+.codex/skills/agent-council/scripts/council-job.sh results "$JOB_DIR"
+.codex/skills/agent-council/scripts/council-job.sh clean "$JOB_DIR"
+```
+
 ## 예시
 
 ```
@@ -167,7 +178,10 @@ agent-council/
 │   └── agent-council/
 │       ├── SKILL.md         # 스킬 문서
 │       └── scripts/
-│           └── council.sh   # 실행 스크립트
+│           ├── council.sh           # 실행 스크립트
+│           ├── council-job.sh       # 백그라운드 Job runner (폴링 가능)
+│           ├── council-job.js       # Job runner 구현
+│           └── council-job-worker.js # 멤버별 워커
 ├── council.config.yaml      # Council 멤버 설정
 ├── README.md                # 영어 문서
 ├── README.ko.md             # 이 문서

--- a/README.ko.md
+++ b/README.ko.md
@@ -69,6 +69,8 @@ npx github:team-attention/agent-council --target both
 /plugin install agent-council@team-attention-plugins
 ```
 
+참고(플러그인 설치): **Job Mode는 Node.js가 필요**하며, Claude Code 플러그인은 Node를 번들/자동 설치할 수 없습니다. Node를 별도로 설치하세요(예: macOS `brew install node`). Node 없이 쓰고 싶다면 순수 shell 스크립트인 `council.sh` 모드를 사용하세요.
+
 ### 2. Agent CLI 설치
 
 Council 멤버로 쓰고 싶은 CLI를 설치하세요(템플릿 기본 포함: `claude`, `codex`, `gemini`):

--- a/README.ko.md
+++ b/README.ko.md
@@ -69,7 +69,7 @@ npx github:team-attention/agent-council --target both
 /plugin install agent-council@team-attention-plugins
 ```
 
-참고(플러그인 설치): **Job Mode는 Node.js가 필요**하며, Claude Code 플러그인은 Node를 번들/자동 설치할 수 없습니다. Node를 별도로 설치하세요(예: macOS `brew install node`). Node 없이 쓰고 싶다면 순수 shell 스크립트인 `council.sh` 모드를 사용하세요.
+참고(플러그인 설치): **Agent Council은 Node.js가 필요**하며, Claude Code 플러그인은 Node를 번들/자동 설치할 수 없습니다. Node를 별도로 설치하세요(예: macOS `brew install node`).
 
 ### 2. Agent CLI 설치
 
@@ -139,20 +139,16 @@ council:
 ### 스크립트 직접 실행
 
 ```bash
-.claude/skills/agent-council/scripts/council.sh "질문 내용"
-# 또는
-.codex/skills/agent-council/scripts/council.sh "질문 내용"
+JOB_DIR=$(.codex/skills/agent-council/scripts/council.sh start "질문 내용")
+.codex/skills/agent-council/scripts/council.sh status --text "$JOB_DIR"
+.codex/skills/agent-council/scripts/council.sh results "$JOB_DIR"
+.codex/skills/agent-council/scripts/council.sh clean "$JOB_DIR"
 ```
 
-### 진행상태 표시 (Job Mode)
-
-호스트 UI에서 긴 `council.sh` 실행이 “실시간으로 갱신되는 느낌”이 약하다면, Job Mode를 쓰면 됩니다. 멤버 실행을 백그라운드에서 병렬로 돌리고, 짧은 명령으로 진행상태를 폴링할 수 있어 TODO/plan 업데이트에 유리합니다.
+원샷 실행(잡 시작 → 대기 → 결과 출력 → 정리):
 
 ```bash
-JOB_DIR=$(.codex/skills/agent-council/scripts/council-job.sh start "질문 내용")
-.codex/skills/agent-council/scripts/council-job.sh status --text "$JOB_DIR"
-.codex/skills/agent-council/scripts/council-job.sh results "$JOB_DIR"
-.codex/skills/agent-council/scripts/council-job.sh clean "$JOB_DIR"
+.codex/skills/agent-council/scripts/council.sh "질문 내용"
 ```
 
 ## 예시

--- a/README.ko.md
+++ b/README.ko.md
@@ -159,9 +159,8 @@ JOB_DIR=$(.codex/skills/agent-council/scripts/council.sh start "질문 내용")
 
 #### 진행상황
 
-- 실제 터미널에서는 원샷이 기본적으로 멀티라인 체크리스트를 표시합니다(한 번의 실행에서 갱신).
+- 실제 터미널에서는 원샷이 멤버 완료에 맞춰 진행상황 라인을 주기적으로 출력합니다.
 - 호스트 에이전트 도구 UI에서는 원샷이 `wait` JSON을 반환합니다(네이티브 plan/todo UI 갱신 목적).
-- `COUNCIL_TUI=0`이면 텍스트 진행상황 라인, `COUNCIL_PROGRESS=0`이면 진행상황 출력 자체를 끕니다.
 - 스크립팅이 필요하면 job mode(`start` → `status` → `results` → `clean`)도 사용할 수 있습니다.
 
 ## 예시

--- a/README.ko.md
+++ b/README.ko.md
@@ -145,11 +145,24 @@ JOB_DIR=$(.codex/skills/agent-council/scripts/council.sh start "질문 내용")
 .codex/skills/agent-council/scripts/council.sh clean "$JOB_DIR"
 ```
 
+팁: `status --text`에 `--verbose`를 추가하면 멤버별 상태 라인이 함께 출력됩니다.
+팁: `status --checklist`는 체크리스트 형태로 간단히 보여줍니다(Codex/Claude tool cell에 유용).
+팁: `wait`를 쓰면 “의미 있는 진행”이 있을 때만 반환해서 tool cell 스팸을 줄일 수 있습니다(JSON 출력, 커서는 자동으로 저장/갱신; 기본값은 멤버 수에 따라 대략 ~5~10번 수준으로 자동 배치, `--bucket 1`이면 매 완료마다 반환).
+
 원샷 실행(잡 시작 → 대기 → 결과 출력 → 정리):
 
 ```bash
 .codex/skills/agent-council/scripts/council.sh "질문 내용"
 ```
+
+참고: 호스트 에이전트 도구 UI(Codex CLI / Claude Code)에서는 원샷이 **블로킹하지 않습니다**. 네이티브 plan/todo UI를 갱신할 수 있도록 `wait` JSON을 한 번 반환하고 종료하며, 이후 `wait` → 네이티브 UI 갱신 → `results` → `clean` 순서로 진행하세요.
+
+#### 진행상황
+
+- 실제 터미널에서는 원샷이 기본적으로 멀티라인 체크리스트를 표시합니다(한 번의 실행에서 갱신).
+- 호스트 에이전트 도구 UI에서는 원샷이 `wait` JSON을 반환합니다(네이티브 plan/todo UI 갱신 목적).
+- `COUNCIL_TUI=0`이면 텍스트 진행상황 라인, `COUNCIL_PROGRESS=0`이면 진행상황 출력 자체를 끕니다.
+- 스크립팅이 필요하면 job mode(`start` → `status` → `results` → `clean`)도 사용할 수 있습니다.
 
 ## 예시
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -39,6 +39,7 @@ npx github:team-attention/agent-council
 ```
 
 현재 프로젝트 디렉토리에 스킬 파일들이 복사됩니다.
+Agent Council을 업그레이드한 뒤 `Missing runtime dependency: yaml` 같은 런타임 에러가 나면, 위 설치 커맨드를 한 번 더 실행해서 설치된 스킬 파일을 갱신하세요.
 
 기본값으로 설치 스크립트가 자동으로 Claude Code(`.claude/`) / Codex CLI(`.codex/`) 설치 여부를 감지해서 가능한 타깃에 설치합니다.
 

--- a/README.md
+++ b/README.md
@@ -159,9 +159,8 @@ Note: In host-agent tool UIs (Codex CLI / Claude Code), one-shot does **not** bl
 
 #### Progress
 
-- In a real terminal, one-shot shows a multi-line checklist by default (in a single run).
+- In a real terminal, one-shot prints periodic progress lines as members complete.
 - In host-agent tool UIs, one-shot returns `wait` JSON (so the host can update native plan/todo UIs).
-- Use `COUNCIL_TUI=0` for plain progress lines, or `COUNCIL_PROGRESS=0` to disable progress output.
 - Job mode is still available for scripting (`start` → `status` → `results` → `clean`).
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ The generated `council.config.yaml` enables only detected member CLIs (e.g. `cla
 /plugin install agent-council@team-attention-plugins
 ```
 
+Note (Plugin installs): **Job mode requires Node.js**, and Claude Code plugins can’t bundle or auto-install Node for you. Install Node separately (e.g. `brew install node` on macOS), or use the non-job `council.sh` mode if you prefer a pure shell script.
+
 ### 2. Install Agent CLIs
 
 Install the CLIs you want to use as council members (template includes `claude`, `codex`, `gemini`):

--- a/README.md
+++ b/README.md
@@ -142,6 +142,17 @@ Ask your host agent to summon the council:
 .codex/skills/agent-council/scripts/council.sh "Your question here"
 ```
 
+### Live Progress (Job Mode)
+
+If your host UI doesn’t feel “live” during a long `council.sh` run, use job mode: it starts member runs in parallel in the background and lets you poll progress with short commands (useful for TODO/plan updates).
+
+```bash
+JOB_DIR=$(.codex/skills/agent-council/scripts/council-job.sh start "Your question here")
+.codex/skills/agent-council/scripts/council-job.sh status --text "$JOB_DIR"
+.codex/skills/agent-council/scripts/council-job.sh results "$JOB_DIR"
+.codex/skills/agent-council/scripts/council-job.sh clean "$JOB_DIR"
+```
+
 ## Example
 
 ```
@@ -167,7 +178,10 @@ agent-council/
 │   └── agent-council/
 │       ├── SKILL.md         # Skill documentation
 │       └── scripts/
-│           └── council.sh   # Execution script
+│           ├── council.sh       # Execution script
+│           ├── council-job.sh   # Background job runner (pollable)
+│           ├── council-job.js   # Job runner implementation
+│           └── council-job-worker.js # Per-member worker
 ├── council.config.yaml      # Council member configuration
 ├── README.md                # This file
 ├── README.ko.md             # Korean documentation

--- a/README.md
+++ b/README.md
@@ -145,11 +145,24 @@ JOB_DIR=$(.codex/skills/agent-council/scripts/council.sh start "Your question he
 .codex/skills/agent-council/scripts/council.sh clean "$JOB_DIR"
 ```
 
+Tip: add `--verbose` to `status --text` to include per-member lines.
+Tip: use `status --checklist` for a compact checkbox view (handy in Codex/Claude tool cells).
+Tip: use `wait` to block until meaningful progress without spamming tool cells (prints JSON, persists a cursor automatically; auto-batches to a small number of updates (typically ~5–10); `--bucket 1` for every completion).
+
 One-shot (runs job → waits → prints results → cleans):
 
 ```bash
 .codex/skills/agent-council/scripts/council.sh "Your question here"
 ```
+
+Note: In host-agent tool UIs (Codex CLI / Claude Code), one-shot does **not** block. It returns a single `wait` JSON payload so the host agent can update native plan/todo UIs. Continue with `wait` → native UI update → `results` → `clean`.
+
+#### Progress
+
+- In a real terminal, one-shot shows a multi-line checklist by default (in a single run).
+- In host-agent tool UIs, one-shot returns `wait` JSON (so the host can update native plan/todo UIs).
+- Use `COUNCIL_TUI=0` for plain progress lines, or `COUNCIL_PROGRESS=0` to disable progress output.
+- Job mode is still available for scripting (`start` → `status` → `results` → `clean`).
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ npx github:team-attention/agent-council
 ```
 
 This copies the skill files to your current project directory.
+If you upgrade Agent Council and hit a runtime error like `Missing runtime dependency: yaml`, re-run the installer command above to refresh your installed skill files.
 
 By default, the installer auto-detects whether to install for Claude Code (`.claude/`) and/or Codex CLI (`.codex/`) based on what’s available on your machine and in the repo.
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The generated `council.config.yaml` enables only detected member CLIs (e.g. `cla
 /plugin install agent-council@team-attention-plugins
 ```
 
-Note (Plugin installs): **Job mode requires Node.js**, and Claude Code plugins can’t bundle or auto-install Node for you. Install Node separately (e.g. `brew install node` on macOS), or use the non-job `council.sh` mode if you prefer a pure shell script.
+Note (Plugin installs): **Agent Council requires Node.js**, and Claude Code plugins can’t bundle or auto-install Node for you. Install Node separately (e.g. `brew install node` on macOS).
 
 ### 2. Install Agent CLIs
 
@@ -139,20 +139,16 @@ Ask your host agent to summon the council:
 ### Direct Script Execution
 
 ```bash
-.claude/skills/agent-council/scripts/council.sh "Your question here"
-# or
-.codex/skills/agent-council/scripts/council.sh "Your question here"
+JOB_DIR=$(.codex/skills/agent-council/scripts/council.sh start "Your question here")
+.codex/skills/agent-council/scripts/council.sh status --text "$JOB_DIR"
+.codex/skills/agent-council/scripts/council.sh results "$JOB_DIR"
+.codex/skills/agent-council/scripts/council.sh clean "$JOB_DIR"
 ```
 
-### Live Progress (Job Mode)
-
-If your host UI doesn’t feel “live” during a long `council.sh` run, use job mode: it starts member runs in parallel in the background and lets you poll progress with short commands (useful for TODO/plan updates).
+One-shot (runs job → waits → prints results → cleans):
 
 ```bash
-JOB_DIR=$(.codex/skills/agent-council/scripts/council-job.sh start "Your question here")
-.codex/skills/agent-council/scripts/council-job.sh status --text "$JOB_DIR"
-.codex/skills/agent-council/scripts/council-job.sh results "$JOB_DIR"
-.codex/skills/agent-council/scripts/council-job.sh clean "$JOB_DIR"
+.codex/skills/agent-council/scripts/council.sh "Your question here"
 ```
 
 ## Example

--- a/bin/install.js
+++ b/bin/install.js
@@ -15,6 +15,7 @@ const packageRoot = path.resolve(__dirname, '..');
 const targetDir = process.cwd();
 const claudeDir = path.join(targetDir, '.claude');
 const codexDir = path.join(targetDir, '.codex');
+const yamlModuleDir = path.dirname(require.resolve('yaml/package.json'));
 
 function parseArgs(argv) {
   const args = argv.slice(2);
@@ -140,6 +141,14 @@ try {
       copyRecursive(skillsSrc, install.skillsDest);
       console.log(`${GREEN}  ✓ ${install.displayPath}${NC}`);
     }
+
+    // Ship runtime dependencies needed by the skill at execution time.
+    const runtimeModulesDir = path.join(install.skillsDest, 'node_modules');
+    if (!fs.existsSync(runtimeModulesDir)) fs.mkdirSync(runtimeModulesDir, { recursive: true });
+
+    console.log(`${YELLOW}Installing runtime deps (${install.label})...${NC}`);
+    copyRecursive(yamlModuleDir, path.join(runtimeModulesDir, 'yaml'));
+    console.log(`${GREEN}  ✓ ${install.displayPath}/node_modules/yaml${NC}`);
 
     // Copy config file to skill folder if not exists
     const configDest = path.join(install.skillsDest, 'council.config.yaml');

--- a/council.config.yaml
+++ b/council.config.yaml
@@ -36,8 +36,6 @@ council:
 
   # Execution settings
   settings:
-    parallel: true          # Run agents in parallel
-    timeout: 120            # (Reserved) Timeout in seconds per agent (not enforced by the script yet)
-    show_thinking: true     # Show "Thinking..." status
+    timeout: 120            # Timeout seconds per agent (0 to disable)
     exclude_chairman_from_members: true  # Avoid calling the chairman as a member by default
     # synthesize: true       # Force Stage 3 synthesis inside council.sh (requires chairman.command or --chairman codex/gemini)

--- a/skills/agent-council/SKILL.md
+++ b/skills/agent-council/SKILL.md
@@ -88,7 +88,7 @@ Notes:
   - One line per member: `[Council] Ask <member>` (checkbox marks completion)
   - `[Council] Synthesize`
   - (With the default config, `N` is usually 2 because the chairman is excluded, so you’ll typically see 4 items total.)
-- Default checklist uses only `pending` → `completed` (no `in_progress`). If you extend it, keep at most one `in_progress` at a time (Codex plan UI expects this).
+- The checklist keeps **exactly one** `in_progress` item while work remains (dispatch → one running member → synthesize) so Codex’s Plan UI stays visible; keep at most one `in_progress` at a time.
 - Don’t run a long `while true` loop in a single shell tool call; update the UI only after each `wait` return (auto-batched), then restore the original list (or remove the `[Council]` section) when finished.
 
 ## Examples

--- a/skills/agent-council/SKILL.md
+++ b/skills/agent-council/SKILL.md
@@ -41,6 +41,24 @@ The Chairman synthesizes all responses and presents the final opinion (usually h
 ./skills/agent-council/scripts/council.sh "your question here"
 ```
 
+### Live Progress (Job Mode)
+
+Some host tools don’t stream stdout/stderr from long-running scripts in a “live terminal” way. Job mode lets you run members in parallel in the background, and poll progress with short commands (good for TODO/plan UIs).
+
+```bash
+# 1) Start a background job (returns immediately)
+JOB_DIR=$(./skills/agent-council/scripts/council-job.sh start "your question here")
+
+# 2) Poll progress (repeat as needed)
+./skills/agent-council/scripts/council-job.sh status --text "$JOB_DIR"
+
+# 3) Print collected outputs
+./skills/agent-council/scripts/council-job.sh results "$JOB_DIR"
+
+# 4) Cleanup
+./skills/agent-council/scripts/council-job.sh clean "$JOB_DIR"
+```
+
 ### Execution via Host Agent
 
 1. Request council summon from your host agent (Claude Code / Codex CLI)

--- a/skills/agent-council/SKILL.md
+++ b/skills/agent-council/SKILL.md
@@ -104,6 +104,7 @@ Council members are configured in `council.config.yaml`. The installer enables o
 
 - Each configured CLI must be installed and authenticated
 - Template includes: Claude CLI, OpenAI Codex CLI, Google Gemini CLI
+- Job mode requires Node.js (plugins can’t bundle or auto-install it)
 
 ### Verify Installation
 

--- a/skills/agent-council/SKILL.md
+++ b/skills/agent-council/SKILL.md
@@ -38,25 +38,16 @@ The Chairman synthesizes all responses and presents the final opinion (usually h
 ### Direct Script Execution
 
 ```bash
-./skills/agent-council/scripts/council.sh "your question here"
+JOB_DIR=$(./skills/agent-council/scripts/council.sh start "your question here")
+./skills/agent-council/scripts/council.sh status --text "$JOB_DIR"
+./skills/agent-council/scripts/council.sh results "$JOB_DIR"
+./skills/agent-council/scripts/council.sh clean "$JOB_DIR"
 ```
 
-### Live Progress (Job Mode)
-
-Some host tools don’t stream stdout/stderr from long-running scripts in a “live terminal” way. Job mode lets you run members in parallel in the background, and poll progress with short commands (good for TODO/plan UIs).
+One-shot (runs job → waits → prints results → cleans):
 
 ```bash
-# 1) Start a background job (returns immediately)
-JOB_DIR=$(./skills/agent-council/scripts/council-job.sh start "your question here")
-
-# 2) Poll progress (repeat as needed)
-./skills/agent-council/scripts/council-job.sh status --text "$JOB_DIR"
-
-# 3) Print collected outputs
-./skills/agent-council/scripts/council-job.sh results "$JOB_DIR"
-
-# 4) Cleanup
-./skills/agent-council/scripts/council-job.sh clean "$JOB_DIR"
+./skills/agent-council/scripts/council.sh "your question here"
 ```
 
 ### Execution via Host Agent
@@ -104,7 +95,7 @@ Council members are configured in `council.config.yaml`. The installer enables o
 
 - Each configured CLI must be installed and authenticated
 - Template includes: Claude CLI, OpenAI Codex CLI, Google Gemini CLI
-- Job mode requires Node.js (plugins can’t bundle or auto-install it)
+- Requires Node.js (plugins can’t bundle or auto-install it)
 
 ### Verify Installation
 

--- a/skills/agent-council/scripts/council-job-worker.js
+++ b/skills/agent-council/scripts/council-job-worker.js
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { spawn } = require('child_process');
+
+function exitWithError(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const out = { _: [] };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (!a.startsWith('--')) {
+      out._.push(a);
+      continue;
+    }
+
+    const [key, rawValue] = a.split('=', 2);
+    if (rawValue != null) {
+      out[key.slice(2)] = rawValue;
+      continue;
+    }
+    const next = args[i + 1];
+    if (next == null || next.startsWith('--')) {
+      out[key.slice(2)] = true;
+      continue;
+    }
+    out[key.slice(2)] = next;
+    i++;
+  }
+  return out;
+}
+
+function splitCommand(command) {
+  const tokens = [];
+  let current = '';
+  let inSingle = false;
+  let inDouble = false;
+  let escapeNext = false;
+
+  for (const ch of String(command || '')) {
+    if (escapeNext) {
+      current += ch;
+      escapeNext = false;
+      continue;
+    }
+
+    if (!inSingle && ch === '\\') {
+      escapeNext = true;
+      continue;
+    }
+
+    if (!inDouble && ch === "'") {
+      inSingle = !inSingle;
+      continue;
+    }
+
+    if (!inSingle && ch === '"') {
+      inDouble = !inDouble;
+      continue;
+    }
+
+    if (!inSingle && !inDouble && /\s/.test(ch)) {
+      if (current) tokens.push(current);
+      current = '';
+      continue;
+    }
+
+    current += ch;
+  }
+
+  if (current) tokens.push(current);
+  if (inSingle || inDouble) return null;
+  return tokens;
+}
+
+function atomicWriteJson(filePath, payload) {
+  const tmpPath = `${filePath}.${process.pid}.${crypto.randomBytes(4).toString('hex')}.tmp`;
+  fs.writeFileSync(tmpPath, JSON.stringify(payload, null, 2), 'utf8');
+  fs.renameSync(tmpPath, filePath);
+}
+
+function main() {
+  const options = parseArgs(process.argv);
+  const jobDir = options['job-dir'];
+  const member = options.member;
+  const safeMember = options['safe-member'];
+  const command = options.command;
+  const timeoutSec = options.timeout ? Number(options.timeout) : 0;
+
+  if (!jobDir) exitWithError('worker: missing --job-dir');
+  if (!member) exitWithError('worker: missing --member');
+  if (!safeMember) exitWithError('worker: missing --safe-member');
+  if (!command) exitWithError('worker: missing --command');
+
+  const membersRoot = path.join(jobDir, 'members');
+  const memberDir = path.join(membersRoot, safeMember);
+  const statusPath = path.join(memberDir, 'status.json');
+  const outPath = path.join(memberDir, 'output.txt');
+  const errPath = path.join(memberDir, 'error.txt');
+
+  const promptPath = path.join(jobDir, 'prompt.txt');
+  const prompt = fs.existsSync(promptPath) ? fs.readFileSync(promptPath, 'utf8') : '';
+
+  const tokens = splitCommand(command);
+  if (!tokens || tokens.length === 0) {
+    atomicWriteJson(statusPath, {
+      member,
+      state: 'error',
+      message: 'Invalid command string',
+      finishedAt: new Date().toISOString(),
+      command,
+    });
+    process.exit(1);
+  }
+
+  const program = tokens[0];
+  const args = tokens.slice(1);
+
+  atomicWriteJson(statusPath, {
+    member,
+    state: 'running',
+    startedAt: new Date().toISOString(),
+    command,
+    pid: null,
+  });
+
+  const outStream = fs.createWriteStream(outPath, { flags: 'w' });
+  const errStream = fs.createWriteStream(errPath, { flags: 'w' });
+
+  let child;
+  try {
+    child = spawn(program, [...args, prompt], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+    });
+  } catch (error) {
+    atomicWriteJson(statusPath, {
+      member,
+      state: 'error',
+      message: error && error.message ? error.message : 'Failed to spawn command',
+      finishedAt: new Date().toISOString(),
+      command,
+    });
+    process.exit(1);
+  }
+
+  atomicWriteJson(statusPath, {
+    member,
+    state: 'running',
+    startedAt: new Date().toISOString(),
+    command,
+    pid: child.pid,
+  });
+
+  if (child.stdout) child.stdout.pipe(outStream);
+  if (child.stderr) child.stderr.pipe(errStream);
+
+  let timeoutHandle = null;
+  if (Number.isFinite(timeoutSec) && timeoutSec > 0) {
+    timeoutHandle = setTimeout(() => {
+      try {
+        process.kill(child.pid, 'SIGTERM');
+      } catch {
+        // ignore
+      }
+    }, timeoutSec * 1000);
+    timeoutHandle.unref();
+  }
+
+  const finalize = (payload) => {
+    try {
+      outStream.end();
+      errStream.end();
+    } catch {
+      // ignore
+    }
+    atomicWriteJson(statusPath, payload);
+  };
+
+  child.on('error', (error) => {
+    const isMissing = error && error.code === 'ENOENT';
+    finalize({
+      member,
+      state: isMissing ? 'missing_cli' : 'error',
+      message: error && error.message ? error.message : 'Process error',
+      finishedAt: new Date().toISOString(),
+      command,
+      exitCode: null,
+      pid: child.pid,
+    });
+    process.exit(1);
+  });
+
+  child.on('exit', (code, signal) => {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+    const timedOut = signal === 'SIGTERM' && Number.isFinite(timeoutSec) && timeoutSec > 0;
+    finalize({
+      member,
+      state: timedOut ? 'timed_out' : code === 0 ? 'done' : 'error',
+      message: timedOut ? `Timed out after ${timeoutSec}s` : null,
+      finishedAt: new Date().toISOString(),
+      command,
+      exitCode: typeof code === 'number' ? code : null,
+      signal: signal || null,
+      pid: child.pid,
+    });
+    process.exit(code === 0 ? 0 : 1);
+  });
+}
+
+if (require.main === module) {
+  main();
+}
+

--- a/skills/agent-council/scripts/council-job.js
+++ b/skills/agent-council/scripts/council-job.js
@@ -1,0 +1,564 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { spawn } = require('child_process');
+
+const SCRIPT_DIR = __dirname;
+const SKILL_DIR = path.resolve(SCRIPT_DIR, '..');
+const WORKER_PATH = path.join(SCRIPT_DIR, 'council-job-worker.js');
+
+const SKILL_CONFIG_FILE = path.join(SKILL_DIR, 'council.config.yaml');
+const REPO_CONFIG_FILE = path.join(path.resolve(SKILL_DIR, '../..'), 'council.config.yaml');
+
+function exitWithError(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+
+function resolveDefaultConfigFile() {
+  if (fs.existsSync(SKILL_CONFIG_FILE)) return SKILL_CONFIG_FILE;
+  if (fs.existsSync(REPO_CONFIG_FILE)) return REPO_CONFIG_FILE;
+  return SKILL_CONFIG_FILE;
+}
+
+function detectHostRole() {
+  const normalized = SKILL_DIR.replace(/\\/g, '/');
+  if (normalized.includes('/.claude/skills/')) return 'claude';
+  if (normalized.includes('/.codex/skills/')) return 'codex';
+  return 'unknown';
+}
+
+function normalizeBool(value) {
+  if (value == null) return null;
+  const v = String(value).trim().toLowerCase();
+  if (['1', 'true', 'yes', 'y', 'on'].includes(v)) return true;
+  if (['0', 'false', 'no', 'n', 'off'].includes(v)) return false;
+  return null;
+}
+
+function resolveAutoRole(role, hostRole) {
+  const roleLc = String(role || '').trim().toLowerCase();
+  if (roleLc && roleLc !== 'auto') return roleLc;
+  if (hostRole === 'codex') return 'codex';
+  if (hostRole === 'claude') return 'claude';
+  return 'claude';
+}
+
+function parseCouncilConfig(configPath) {
+  const fallback = {
+    council: {
+      chairman: { role: 'auto' },
+      members: [
+        { name: 'claude', command: 'claude -p', emoji: '🧠', color: 'CYAN' },
+        { name: 'codex', command: 'codex exec', emoji: '🤖', color: 'BLUE' },
+        { name: 'gemini', command: 'gemini', emoji: '💎', color: 'GREEN' },
+      ],
+      settings: { exclude_chairman_from_members: true, timeout: 120, parallel: true },
+    },
+  };
+
+  if (!fs.existsSync(configPath)) return fallback;
+
+  const content = fs.readFileSync(configPath, 'utf8');
+  const lines = content.split(/\r?\n/);
+
+  const result = { council: { chairman: {}, members: [], settings: {} } };
+  let inCouncil = false;
+  let councilIndent = 0;
+  let inMembers = false;
+  let membersIndent = 0;
+  let inChairman = false;
+  let chairmanIndent = 0;
+  let inSettings = false;
+  let settingsIndent = 0;
+
+  let currentMember = null;
+
+  function finalizeMember() {
+    if (!currentMember) return;
+    if (currentMember.name && currentMember.command) {
+      result.council.members.push(currentMember);
+    }
+    currentMember = null;
+  }
+
+  function lineIndent(line) {
+    const match = line.match(/^(\s*)/);
+    return match ? match[1].length : 0;
+  }
+
+  function stripInlineComment(value) {
+    const v = String(value || '').trim();
+    if (!v) return v;
+    const hashIndex = v.indexOf('#');
+    if (hashIndex === -1) return v;
+    return v.slice(0, hashIndex).trim();
+  }
+
+  function stripQuotes(value) {
+    const v = stripInlineComment(value).trim();
+    if (!v) return v;
+    if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+      return v.slice(1, -1);
+    }
+    return v;
+  }
+
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/\t/g, '    ');
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const indent = lineIndent(line);
+
+    if (!inCouncil) {
+      if (trimmed === 'council:' || trimmed.startsWith('council:')) {
+        inCouncil = true;
+        councilIndent = indent;
+      }
+      continue;
+    }
+
+    if (indent <= councilIndent && !trimmed.startsWith('-')) {
+      inCouncil = false;
+      inMembers = false;
+      inChairman = false;
+      inSettings = false;
+      continue;
+    }
+
+    if (inMembers && indent <= membersIndent && !trimmed.startsWith('-')) {
+      finalizeMember();
+      inMembers = false;
+    }
+    if (inChairman && indent <= chairmanIndent) inChairman = false;
+    if (inSettings && indent <= settingsIndent) inSettings = false;
+
+    if (!inMembers && trimmed === 'members:') {
+      inMembers = true;
+      membersIndent = indent;
+      continue;
+    }
+    if (!inChairman && trimmed === 'chairman:') {
+      inChairman = true;
+      chairmanIndent = indent;
+      continue;
+    }
+    if (!inSettings && trimmed === 'settings:') {
+      inSettings = true;
+      settingsIndent = indent;
+      continue;
+    }
+
+    if (inMembers) {
+      const nameMatch = trimmed.match(/^- name:\s*(.+)$/);
+      if (nameMatch) {
+        finalizeMember();
+        currentMember = { name: stripQuotes(nameMatch[1]) };
+        continue;
+      }
+
+      const keyMatch = trimmed.match(/^([a-zA-Z0-9_]+):\s*(.*)$/);
+      if (keyMatch && currentMember) {
+        const key = keyMatch[1];
+        const value = stripQuotes(keyMatch[2]);
+        if (key === 'command') currentMember.command = value;
+        else if (key === 'emoji') currentMember.emoji = value;
+        else if (key === 'color') currentMember.color = value;
+      }
+      continue;
+    }
+
+    if (inChairman) {
+      const roleMatch = trimmed.match(/^(role|name):\s*(.+)$/);
+      if (roleMatch) {
+        result.council.chairman.role = stripQuotes(roleMatch[2]);
+      }
+      continue;
+    }
+
+    if (inSettings) {
+      const keyMatch = trimmed.match(/^([a-zA-Z0-9_]+):\s*(.+)$/);
+      if (keyMatch) {
+        const key = keyMatch[1];
+        const value = stripQuotes(keyMatch[2]);
+        result.council.settings[key] = value;
+      }
+      continue;
+    }
+  }
+
+  finalizeMember();
+  if (result.council.members.length === 0) return fallback;
+  return result;
+}
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function safeFileName(name) {
+  const cleaned = String(name || '').trim().toLowerCase().replace(/[^a-z0-9_-]+/g, '-');
+  return cleaned || 'member';
+}
+
+function atomicWriteJson(filePath, payload) {
+  const tmpPath = `${filePath}.${process.pid}.${crypto.randomBytes(4).toString('hex')}.tmp`;
+  fs.writeFileSync(tmpPath, JSON.stringify(payload, null, 2), 'utf8');
+  fs.renameSync(tmpPath, filePath);
+}
+
+function readJsonIfExists(filePath) {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const out = { _: [] };
+  const booleanFlags = new Set([
+    'json',
+    'text',
+    'help',
+    'h',
+    'include-chairman',
+    'exclude-chairman',
+  ]);
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--') {
+      out._.push(...args.slice(i + 1));
+      break;
+    }
+    if (!a.startsWith('--')) {
+      out._.push(a);
+      continue;
+    }
+
+    const [key, rawValue] = a.split('=', 2);
+    if (rawValue != null) {
+      out[key.slice(2)] = rawValue;
+      continue;
+    }
+
+    const normalizedKey = key.slice(2);
+    if (booleanFlags.has(normalizedKey)) {
+      out[normalizedKey] = true;
+      continue;
+    }
+
+    const next = args[i + 1];
+    if (next == null || next.startsWith('--')) {
+      out[normalizedKey] = true;
+      continue;
+    }
+    out[normalizedKey] = next;
+    i++;
+  }
+  return out;
+}
+
+function printHelp() {
+  process.stdout.write(`Agent Council (job mode)
+
+Usage:
+  council-job.sh start [--config path] [--chairman auto|claude|codex|...] [--jobs-dir path] [--json] "question"
+  council-job.sh status [--json|--text] <jobDir>
+  council-job.sh results [--json] <jobDir>
+  council-job.sh stop <jobDir>
+  council-job.sh clean <jobDir>
+
+Notes:
+  - start returns immediately and runs members in parallel via detached Node workers
+  - poll status with repeated short calls to update TODO/plan UIs in host agents
+`);
+}
+
+function cmdStart(options, prompt) {
+  const configPath = options.config || process.env.COUNCIL_CONFIG || resolveDefaultConfigFile();
+  const jobsDir =
+    options['jobs-dir'] || process.env.COUNCIL_JOBS_DIR || path.join(SKILL_DIR, '.jobs');
+
+  ensureDir(jobsDir);
+
+  const hostRole = detectHostRole();
+  const config = parseCouncilConfig(configPath);
+  const chairmanRoleRaw = options.chairman || process.env.COUNCIL_CHAIRMAN || config.council.chairman.role || 'auto';
+  const chairmanRole = resolveAutoRole(chairmanRoleRaw, hostRole);
+
+  const includeChairman = Boolean(options['include-chairman']);
+  const excludeChairmanOverride =
+    options['exclude-chairman'] != null ? true : options['include-chairman'] != null ? false : null;
+
+  const excludeSetting = normalizeBool(config.council.settings.exclude_chairman_from_members);
+  const excludeChairmanFromMembers =
+    excludeChairmanOverride != null ? excludeChairmanOverride : excludeSetting != null ? excludeSetting : true;
+
+  const timeoutSetting = Number(config.council.settings.timeout || 0);
+  const timeoutOverride = options.timeout != null ? Number(options.timeout) : null;
+  const timeoutSec = Number.isFinite(timeoutOverride) && timeoutOverride > 0 ? timeoutOverride : timeoutSetting > 0 ? timeoutSetting : 0;
+
+  const requestedMembers = config.council.members || [];
+  const members = requestedMembers.filter((m) => {
+    if (!m || !m.name || !m.command) return false;
+    const nameLc = String(m.name).toLowerCase();
+    if (excludeChairmanFromMembers && !includeChairman && nameLc === chairmanRole) return false;
+    return true;
+  });
+
+  const jobId = `${new Date().toISOString().replace(/[:.]/g, '').replace('T', '-').slice(0, 15)}-${crypto
+    .randomBytes(3)
+    .toString('hex')}`;
+  const jobDir = path.join(jobsDir, `council-${jobId}`);
+  const membersDir = path.join(jobDir, 'members');
+  ensureDir(membersDir);
+
+  fs.writeFileSync(path.join(jobDir, 'prompt.txt'), String(prompt), 'utf8');
+
+  const jobMeta = {
+    id: `council-${jobId}`,
+    createdAt: new Date().toISOString(),
+    configPath,
+    hostRole,
+    chairmanRole,
+    settings: {
+      excludeChairmanFromMembers,
+      timeoutSec: timeoutSec || null,
+    },
+    members: members.map((m) => ({
+      name: String(m.name),
+      command: String(m.command),
+      emoji: m.emoji ? String(m.emoji) : null,
+      color: m.color ? String(m.color) : null,
+    })),
+  };
+  atomicWriteJson(path.join(jobDir, 'job.json'), jobMeta);
+
+  for (const member of members) {
+    const name = String(member.name);
+    const safeName = safeFileName(name);
+    const memberDir = path.join(membersDir, safeName);
+    ensureDir(memberDir);
+
+    atomicWriteJson(path.join(memberDir, 'status.json'), {
+      member: name,
+      state: 'queued',
+      queuedAt: new Date().toISOString(),
+      command: String(member.command),
+    });
+
+    const workerArgs = [
+      WORKER_PATH,
+      '--job-dir',
+      jobDir,
+      '--member',
+      name,
+      '--safe-member',
+      safeName,
+      '--command',
+      String(member.command),
+    ];
+    if (timeoutSec && Number.isFinite(timeoutSec) && timeoutSec > 0) {
+      workerArgs.push('--timeout', String(timeoutSec));
+    }
+
+    const child = spawn(process.execPath, workerArgs, {
+      detached: true,
+      stdio: 'ignore',
+      env: process.env,
+    });
+    child.unref();
+  }
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify({ jobDir, ...jobMeta }, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${jobDir}\n`);
+  }
+}
+
+function cmdStatus(options, jobDir) {
+  const resolvedJobDir = path.resolve(jobDir);
+  const jobMeta = readJsonIfExists(path.join(resolvedJobDir, 'job.json'));
+  const membersRoot = path.join(resolvedJobDir, 'members');
+
+  const members = [];
+  if (fs.existsSync(membersRoot)) {
+    for (const entry of fs.readdirSync(membersRoot)) {
+      const statusPath = path.join(membersRoot, entry, 'status.json');
+      const status = readJsonIfExists(statusPath);
+      if (status) members.push({ safeName: entry, ...status });
+    }
+  }
+
+  const totals = { queued: 0, running: 0, done: 0, error: 0, missing_cli: 0, timed_out: 0, canceled: 0 };
+  for (const m of members) {
+    const state = String(m.state || 'unknown');
+    if (Object.prototype.hasOwnProperty.call(totals, state)) totals[state]++;
+  }
+
+  const allDone = members.length > 0 && totals.running === 0 && totals.queued === 0;
+  const overallState = allDone ? 'done' : totals.running > 0 ? 'running' : 'queued';
+
+  const payload = {
+    jobDir: resolvedJobDir,
+    id: jobMeta ? jobMeta.id : null,
+    chairmanRole: jobMeta ? jobMeta.chairmanRole : null,
+    overallState,
+    counts: { total: members.length, ...totals },
+    members: members
+      .map((m) => ({
+        member: m.member,
+        state: m.state,
+        startedAt: m.startedAt || null,
+        finishedAt: m.finishedAt || null,
+        exitCode: m.exitCode != null ? m.exitCode : null,
+        message: m.message || null,
+      }))
+      .sort((a, b) => String(a.member).localeCompare(String(b.member))),
+  };
+
+  const wantText = Boolean(options.text) && !options.json;
+  if (wantText) {
+    const done = payload.counts.done + payload.counts.missing_cli + payload.counts.error + payload.counts.timed_out + payload.counts.canceled;
+    process.stdout.write(`members ${done}/${payload.counts.total} done; running=${payload.counts.running} queued=${payload.counts.queued}\n`);
+    for (const m of payload.members) {
+      process.stdout.write(`- ${m.member}: ${m.state}${m.exitCode != null ? ` (exit ${m.exitCode})` : ''}\n`);
+    }
+    return;
+  }
+
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function cmdResults(options, jobDir) {
+  const resolvedJobDir = path.resolve(jobDir);
+  const jobMeta = readJsonIfExists(path.join(resolvedJobDir, 'job.json'));
+  const membersRoot = path.join(resolvedJobDir, 'members');
+
+  const members = [];
+  if (fs.existsSync(membersRoot)) {
+    for (const entry of fs.readdirSync(membersRoot)) {
+      const statusPath = path.join(membersRoot, entry, 'status.json');
+      const outputPath = path.join(membersRoot, entry, 'output.txt');
+      const status = readJsonIfExists(statusPath);
+      if (!status) continue;
+      const output = fs.existsSync(outputPath) ? fs.readFileSync(outputPath, 'utf8') : '';
+      members.push({ safeName: entry, ...status, output });
+    }
+  }
+
+  if (options.json) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          jobDir: resolvedJobDir,
+          id: jobMeta ? jobMeta.id : null,
+          prompt: fs.existsSync(path.join(resolvedJobDir, 'prompt.txt'))
+            ? fs.readFileSync(path.join(resolvedJobDir, 'prompt.txt'), 'utf8')
+            : null,
+          members: members
+            .map((m) => ({
+              member: m.member,
+              state: m.state,
+              exitCode: m.exitCode != null ? m.exitCode : null,
+              output: m.output,
+            }))
+            .sort((a, b) => String(a.member).localeCompare(String(b.member))),
+        },
+        null,
+        2
+      )}\n`
+    );
+    return;
+  }
+
+  for (const m of members.sort((a, b) => String(a.member).localeCompare(String(b.member)))) {
+    process.stdout.write(`\n=== ${m.member} (${m.state}) ===\n`);
+    process.stdout.write(m.output || '');
+    process.stdout.write('\n');
+  }
+}
+
+function cmdStop(_options, jobDir) {
+  const resolvedJobDir = path.resolve(jobDir);
+  const membersRoot = path.join(resolvedJobDir, 'members');
+  if (!fs.existsSync(membersRoot)) exitWithError(`No members folder found: ${membersRoot}`);
+
+  let stoppedAny = false;
+  for (const entry of fs.readdirSync(membersRoot)) {
+    const statusPath = path.join(membersRoot, entry, 'status.json');
+    const status = readJsonIfExists(statusPath);
+    if (!status) continue;
+    if (status.state !== 'running') continue;
+    if (!status.pid) continue;
+
+    try {
+      process.kill(Number(status.pid), 'SIGTERM');
+      stoppedAny = true;
+    } catch {
+      // ignore
+    }
+  }
+
+  process.stdout.write(stoppedAny ? 'stop: sent SIGTERM to running members\n' : 'stop: no running members\n');
+}
+
+function cmdClean(_options, jobDir) {
+  const resolvedJobDir = path.resolve(jobDir);
+  fs.rmSync(resolvedJobDir, { recursive: true, force: true });
+  process.stdout.write(`cleaned: ${resolvedJobDir}\n`);
+}
+
+function main() {
+  const options = parseArgs(process.argv);
+  const [command, ...rest] = options._;
+
+  if (!command || options.help || options.h) {
+    printHelp();
+    return;
+  }
+
+  if (command === 'start') {
+    const prompt = rest.join(' ').trim();
+    if (!prompt) exitWithError('start: missing prompt');
+    cmdStart(options, prompt);
+    return;
+  }
+  if (command === 'status') {
+    const jobDir = rest[0];
+    if (!jobDir) exitWithError('status: missing jobDir');
+    cmdStatus(options, jobDir);
+    return;
+  }
+  if (command === 'results') {
+    const jobDir = rest[0];
+    if (!jobDir) exitWithError('results: missing jobDir');
+    cmdResults(options, jobDir);
+    return;
+  }
+  if (command === 'stop') {
+    const jobDir = rest[0];
+    if (!jobDir) exitWithError('stop: missing jobDir');
+    cmdStop(options, jobDir);
+    return;
+  }
+  if (command === 'clean') {
+    const jobDir = rest[0];
+    if (!jobDir) exitWithError('clean: missing jobDir');
+    cmdClean(options, jobDir);
+    return;
+  }
+
+  exitWithError(`Unknown command: ${command}`);
+}
+
+if (require.main === module) {
+  main();
+}

--- a/skills/agent-council/scripts/council-job.js
+++ b/skills/agent-council/scripts/council-job.js
@@ -55,7 +55,7 @@ function parseCouncilConfig(configPath) {
         { name: 'codex', command: 'codex exec', emoji: '🤖', color: 'BLUE' },
         { name: 'gemini', command: 'gemini', emoji: '💎', color: 'GREEN' },
       ],
-      settings: { exclude_chairman_from_members: true, timeout: 120, parallel: true },
+      settings: { exclude_chairman_from_members: true, timeout: 120 },
     },
   };
 

--- a/skills/agent-council/scripts/council-job.sh
+++ b/skills/agent-council/scripts/council-job.sh
@@ -3,5 +3,14 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec node "$SCRIPT_DIR/council-job.js" "$@"
 
+if ! command -v node >/dev/null 2>&1; then
+  echo "Error: Node.js is required to run Agent Council job mode." >&2
+  echo "Install Node.js and try again (plugin installs cannot bundle Node)." >&2
+  echo "" >&2
+  echo "macOS (Homebrew): brew install node" >&2
+  echo "Or download from: https://nodejs.org/" >&2
+  exit 127
+fi
+
+exec node "$SCRIPT_DIR/council-job.js" "$@"

--- a/skills/agent-council/scripts/council-job.sh
+++ b/skills/agent-council/scripts/council-job.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec node "$SCRIPT_DIR/council-job.js" "$@"
+

--- a/skills/agent-council/scripts/council.sh
+++ b/skills/agent-council/scripts/council.sh
@@ -4,14 +4,16 @@
 #
 # Subcommands:
 #   council.sh start [options] "question"     # returns JOB_DIR immediately
-#   council.sh status [--json|--text] JOB_DIR # poll progress
+#   council.sh status [--json|--text|--checklist] JOB_DIR # poll progress
+#   council.sh wait [--cursor CURSOR] [--bucket auto|N] [--interval-ms N] [--timeout-ms N] JOB_DIR
 #   council.sh results [--json] JOB_DIR       # print collected outputs
 #   council.sh stop JOB_DIR                   # best-effort stop running members
 #   council.sh clean JOB_DIR                  # remove job directory
 #
 # One-shot:
 #   council.sh "question"
-#   (starts a job, waits for completion, prints results, cleans up)
+#   (in a real terminal: starts a job, waits for completion, prints results, cleans up)
+#   (in host-agent tool UIs: returns a single `wait` JSON payload immediately; host drives progress + results)
 #
 
 set -e
@@ -27,7 +29,8 @@ Default mode is job-based parallel execution (pollable).
 
 Usage:
   $(basename "$0") start [options] "question"
-  $(basename "$0") status [--json|--text] <jobDir>
+  $(basename "$0") status [--json|--text|--checklist] <jobDir>
+  $(basename "$0") wait [--cursor CURSOR] [--bucket auto|N] [--interval-ms N] [--timeout-ms N] <jobDir>
   $(basename "$0") results [--json] <jobDir>
   $(basename "$0") stop <jobDir>
   $(basename "$0") clean <jobDir>
@@ -59,20 +62,172 @@ if ! command -v node >/dev/null 2>&1; then
 fi
 
 case "$1" in
-  start|status|results|stop|clean)
+  start|status|wait|results|stop|clean)
     exec "$JOB_SCRIPT" "$@"
     ;;
 esac
 
+in_host_agent_context() {
+  if [ -n "${CODEX_CACHE_FILE:-}" ]; then
+    return 0
+  fi
+
+  case "$SCRIPT_DIR" in
+    */.codex/skills/*|*/.claude/skills/*)
+      # Tool-call environments typically do not provide a real TTY on stdout/stderr.
+      if [ ! -t 1 ] && [ ! -t 2 ]; then
+        return 0
+      fi
+      ;;
+  esac
+
+  return 1
+}
+
 JOB_DIR="$("$JOB_SCRIPT" start "$@")"
 
+# Host agents (Codex CLI / Claude Code) cannot update native TODO/plan UIs while a long-running
+# command is executing. If we're in a host agent context, return immediately with a single `wait`
+# JSON payload (includes `.ui.codex.update_plan.plan` / `.ui.claude.todo_write.todos`) and let the
+# host agent drive progress updates with repeated short `wait` calls + native UI updates.
+if in_host_agent_context; then
+  exec "$JOB_SCRIPT" wait "$JOB_DIR"
+fi
+
+SHOW_PROGRESS="${COUNCIL_PROGRESS:-1}"
+TUI_MODE="${COUNCIL_TUI:-auto}"
+TUI_MODE_NORM="$(printf '%s' "$TUI_MODE" | tr '[:upper:]' '[:lower:]')"
+if [ -z "$TUI_MODE_NORM" ]; then
+  TUI_MODE_NORM="auto"
+fi
+USE_CHECKLIST="0"
+CHECKLIST_ACTIVE="0"
+LAST_PROGRESS_LINE=""
+LAST_CHECKLIST_SCREEN=""
+LAST_CHECKLIST_KEY=""
+CHECKLIST_LINES="0"
+
+checklist_enter() {
+  # Hide cursor for nicer redraws when ANSI is supported
+  if can_use_ansi; then
+    CHECKLIST_ACTIVE="1"
+    printf '\033[?25l\033[0m' >&2
+  fi
+}
+
+checklist_exit() {
+  if [ "$CHECKLIST_ACTIVE" = "1" ]; then
+    CHECKLIST_ACTIVE="0"
+    printf '\033[?25h\033[0m\n' >&2
+  fi
+}
+
+checklist_render() {
+  local screen="$1"
+  case "$screen" in
+    *$'\n') ;;
+    *) screen="${screen}"$'\n' ;;
+  esac
+  if can_use_ansi; then
+    if [ "${CHECKLIST_LINES:-0}" -gt 0 ]; then
+      printf '\033[%dA' "$CHECKLIST_LINES" >&2
+    fi
+    printf '\033[J' >&2
+    printf '%s' "$screen" >&2
+    CHECKLIST_LINES="$(printf '%s' "$screen" | awk 'END{print NR}')"
+  else
+    printf '%s' "$screen" >&2
+  fi
+}
+
+ui_cleanup() {
+  checklist_exit
+}
+
+can_use_ansi() {
+  # Requires a real terminal on stderr; some host UIs may not render cursor movement/clears.
+  [ -t 2 ] && [ "${TERM:-dumb}" != "dumb" ]
+}
+
+if [ "$SHOW_PROGRESS" != "0" ]; then
+  case "$TUI_MODE_NORM" in
+    0|false|no|n|off)
+      USE_CHECKLIST="0"
+      ;;
+    checklist|checks|checkboxes)
+      USE_CHECKLIST="1"
+      ;;
+    1|true|yes|y|on|auto|*)
+      USE_CHECKLIST="1"
+      ;;
+  esac
+fi
+
+if [ "$USE_CHECKLIST" = "1" ]; then
+  trap ui_cleanup EXIT INT TERM
+  checklist_enter
+fi
+
 while true; do
-  OVERALL="$("$JOB_SCRIPT" status --json "$JOB_DIR" | node -e 'const fs=require("fs");const d=JSON.parse(fs.readFileSync(0,"utf8"));process.stdout.write(String(d.overallState||""));')"
+  STATUS_JSON="$("$JOB_SCRIPT" status --json "$JOB_DIR")"
+  if [ "$USE_CHECKLIST" = "1" ]; then
+    STATUS_INFO="$(printf '%s' "$STATUS_JSON" | node -e '
+const fs=require("fs");
+const d=JSON.parse(fs.readFileSync(0,"utf8"));
+const counts=d.counts||{};
+const done=(counts.done||0)+(counts.missing_cli||0)+(counts.error||0)+(counts.timed_out||0)+(counts.canceled||0);
+const total=counts.total||0;
+const members=(d.members||[]).slice().sort((a,b)=>String(a.member).localeCompare(String(b.member)));
+const key=`${done}/${total}`;
+const mark=(state)=>state==="done" ? "[x]" : (state==="running"||state==="queued") ? "[ ]" : "[!]";
+const lines=[];
+lines.push("Agent Council");
+if (d.id) lines.push(`Job: ${d.id}`);
+lines.push(`Progress: ${done}/${total} done  (running ${counts.running||0}, queued ${counts.queued||0})`);
+for (const m of members) {
+  const state=String(m.state||"");
+  const display=(state==="running"||state==="queued") ? "working" : state;
+  lines.push(`${mark(state)} ${m.member} — ${display}${m.exitCode!=null ? ` (exit ${m.exitCode})` : ""}`);
+}
+process.stdout.write(String(d.overallState||"") + "\n" + key + "\n" + lines.join("\n") + "\n");
+')"
+    OVERALL="${STATUS_INFO%%$'\n'*}"
+    REST="${STATUS_INFO#*$'\n'}"
+    CHECKLIST_KEY="${REST%%$'\n'*}"
+    CHECKLIST_SCREEN="${REST#*$'\n'}"
+    if [ "$CHECKLIST_KEY" != "$LAST_CHECKLIST_KEY" ]; then
+      checklist_render "$CHECKLIST_SCREEN"
+      LAST_CHECKLIST_KEY="$CHECKLIST_KEY"
+      LAST_CHECKLIST_SCREEN="$CHECKLIST_SCREEN"
+    fi
+  else
+    STATUS_INFO="$(printf '%s' "$STATUS_JSON" | node -e '
+const fs=require("fs");
+const d=JSON.parse(fs.readFileSync(0,"utf8"));
+const counts=d.counts||{};
+const done=(counts.done||0)+(counts.missing_cli||0)+(counts.error||0)+(counts.timed_out||0)+(counts.canceled||0);
+const total=counts.total||0;
+const summary=`council: ${done}/${total} done; running=${counts.running||0} queued=${counts.queued||0}`;
+process.stdout.write(String(d.overallState||"") + "\n" + summary);
+')"
+    OVERALL="${STATUS_INFO%%$'\n'*}"
+    PROGRESS_LINE="${STATUS_INFO#*$'\n'}"
+
+    if [ "$SHOW_PROGRESS" != "0" ] && [ "$PROGRESS_LINE" != "$LAST_PROGRESS_LINE" ]; then
+      echo "$PROGRESS_LINE" >&2
+      LAST_PROGRESS_LINE="$PROGRESS_LINE"
+    fi
+  fi
   if [ "$OVERALL" = "done" ]; then
     break
   fi
   sleep 0.5
 done
+
+if [ "$USE_CHECKLIST" = "1" ]; then
+  checklist_exit
+  trap - EXIT INT TERM
+fi
 
 "$JOB_SCRIPT" results "$JOB_DIR"
 "$JOB_SCRIPT" clean "$JOB_DIR" >/dev/null

--- a/skills/agent-council/scripts/council.sh
+++ b/skills/agent-council/scripts/council.sh
@@ -1,516 +1,78 @@
 #!/bin/bash
 #
-# Agent Council - Collect opinions from multiple AI Agents
+# Agent Council (job mode default)
 #
-# Usage:
-#   council.sh [options] "question or prompt"
+# Subcommands:
+#   council.sh start [options] "question"     # returns JOB_DIR immediately
+#   council.sh status [--json|--text] JOB_DIR # poll progress
+#   council.sh results [--json] JOB_DIR       # print collected outputs
+#   council.sh stop JOB_DIR                   # best-effort stop running members
+#   council.sh clean JOB_DIR                  # remove job directory
 #
-# Options:
-#   -c, --config <path>           Use a specific config file path
-#       --chairman <role|auto>    Set chairman role (auto|claude|codex|gemini|...)
-#       --chairman-command <cmd>  Run Stage 3 synthesis via this CLI command
-#       --synthesize              Force Stage 3 synthesis (requires chairman command or inferrable)
-#       --no-synthesize           Disable Stage 3 synthesis (default when no chairman command)
-#       --include-chairman        Do not filter chairman out of members
-#       --exclude-chairman        Filter chairman out of members (default)
-#   -h, --help                    Show help
-#
-# LLM Council (Karpathy) concept:
-# - Stage 1: Send same question to each Agent
-# - Stage 2: Collect and output responses
-# - Stage 3: Chairman synthesizes (optional; can be external or via CLI)
+# One-shot:
+#   council.sh "question"
+#   (starts a job, waits for completion, prints results, cleans up)
 #
 
 set -e
 
-# Get script directory and find config
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-SKILL_CONFIG_FILE="$SKILL_DIR/council.config.yaml"
-REPO_CONFIG_FILE="$(cd "$SKILL_DIR/../.." && pwd)/council.config.yaml"
-
-resolve_default_config_file() {
-    if [ -f "$SKILL_CONFIG_FILE" ]; then
-        echo "$SKILL_CONFIG_FILE"
-    elif [ -f "$REPO_CONFIG_FILE" ]; then
-        echo "$REPO_CONFIG_FILE"
-    else
-        echo "$SKILL_CONFIG_FILE"
-    fi
-}
-
-DEFAULT_CONFIG_FILE="$(resolve_default_config_file)"
-
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-MAGENTA='\033[0;35m'
-NC='\033[0m' # No Color
+JOB_SCRIPT="$SCRIPT_DIR/council-job.sh"
 
 usage() {
-    cat <<EOF
-Agent Council - Collect opinions from multiple AI Agents
+  cat <<EOF
+Agent Council
+
+Default mode is job-based parallel execution (pollable).
 
 Usage:
-  $(basename "$0") [options] "question or prompt"
+  $(basename "$0") start [options] "question"
+  $(basename "$0") status [--json|--text] <jobDir>
+  $(basename "$0") results [--json] <jobDir>
+  $(basename "$0") stop <jobDir>
+  $(basename "$0") clean <jobDir>
 
-Options:
-  -c, --config <path>           Use a specific config file path
-      --chairman <role|auto>    Set chairman role (auto|claude|codex|gemini|...)
-      --chairman-command <cmd>  Run Stage 3 synthesis via this CLI command
-      --synthesize              Force Stage 3 synthesis (requires chairman command or inferrable)
-      --no-synthesize           Disable Stage 3 synthesis
-      --include-chairman        Do not filter chairman out of members
-      --exclude-chairman        Filter chairman out of members (default)
-  -h, --help                    Show help
-
-Environment overrides:
-  COUNCIL_CONFIG                Same as --config
-  COUNCIL_CHAIRMAN              Same as --chairman
-  COUNCIL_CHAIRMAN_COMMAND      Same as --chairman-command
+One-shot:
+  $(basename "$0") "question"
 EOF
 }
 
-# Color name to code mapping
-get_color_code() {
-    case "$1" in
-        RED) echo "$RED" ;;
-        GREEN) echo "$GREEN" ;;
-        BLUE) echo "$BLUE" ;;
-        YELLOW) echo "$YELLOW" ;;
-        CYAN) echo "$CYAN" ;;
-        MAGENTA) echo "$MAGENTA" ;;
-        *) echo "$NC" ;;
-    esac
-}
+if [ $# -eq 0 ]; then
+  usage
+  exit 1
+fi
 
-detect_host() {
-    case "$SKILL_DIR" in
-        */.claude/skills/*) echo "claude" ;;
-        */.codex/skills/*) echo "codex" ;;
-        *) echo "unknown" ;;
-    esac
-}
+case "$1" in
+  -h|--help|help)
+    usage
+    exit 0
+    ;;
+esac
 
-CONFIG_FILE="${COUNCIL_CONFIG:-$DEFAULT_CONFIG_FILE}"
-CHAIRMAN_OVERRIDE="${COUNCIL_CHAIRMAN:-}"
-CHAIRMAN_COMMAND_OVERRIDE="${COUNCIL_CHAIRMAN_COMMAND:-}"
-SYNTHESIZE_OVERRIDE=""
-EXCLUDE_CHAIRMAN_OVERRIDE=""
+if ! command -v node >/dev/null 2>&1; then
+  echo "Error: Node.js is required to run Agent Council." >&2
+  echo "Claude Code plugins cannot bundle or auto-install Node." >&2
+  echo "" >&2
+  echo "macOS (Homebrew): brew install node" >&2
+  echo "Or download from: https://nodejs.org/" >&2
+  exit 127
+fi
 
-PROMPT_ARGS=()
-while [ $# -gt 0 ]; do
-    case "$1" in
-        -c|--config)
-            CONFIG_FILE="$2"
-            shift 2
-            ;;
-        --chairman)
-            CHAIRMAN_OVERRIDE="$2"
-            shift 2
-            ;;
-        --chairman-command)
-            CHAIRMAN_COMMAND_OVERRIDE="$2"
-            shift 2
-            ;;
-        --synthesize)
-            SYNTHESIZE_OVERRIDE="true"
-            shift
-            ;;
-        --no-synthesize)
-            SYNTHESIZE_OVERRIDE="false"
-            shift
-            ;;
-        --include-chairman)
-            EXCLUDE_CHAIRMAN_OVERRIDE="false"
-            shift
-            ;;
-        --exclude-chairman)
-            EXCLUDE_CHAIRMAN_OVERRIDE="true"
-            shift
-            ;;
-        -h|--help)
-            usage
-            exit 0
-            ;;
-        --)
-            shift
-            PROMPT_ARGS+=("$@")
-            break
-            ;;
-        -*)
-            echo -e "${RED}Error: Unknown option: $1${NC}" >&2
-            usage >&2
-            exit 2
-            ;;
-        *)
-            PROMPT_ARGS+=("$1")
-            shift
-            ;;
-    esac
+case "$1" in
+  start|status|results|stop|clean)
+    exec "$JOB_SCRIPT" "$@"
+    ;;
+esac
+
+JOB_DIR="$("$JOB_SCRIPT" start "$@")"
+
+while true; do
+  OVERALL="$("$JOB_SCRIPT" status --json "$JOB_DIR" | node -e 'const fs=require("fs");const d=JSON.parse(fs.readFileSync(0,"utf8"));process.stdout.write(String(d.overallState||""));')"
+  if [ "$OVERALL" = "done" ]; then
+    break
+  fi
+  sleep 0.5
 done
 
-if [ ${#PROMPT_ARGS[@]} -eq 0 ]; then
-    echo -e "${RED}Error: Please provide a prompt${NC}" >&2
-    usage >&2
-    exit 1
-fi
-
-PROMPT="${PROMPT_ARGS[*]}"
-TEMP_DIR=$(mktemp -d)
-trap "rm -rf '$TEMP_DIR'" EXIT
-
-# Parse YAML config (simple parser for our structure - macOS compatible)
-parse_members() {
-    if [ ! -f "$CONFIG_FILE" ]; then
-        echo -e "${YELLOW}Warning: Config file not found at $CONFIG_FILE${NC}" >&2
-        echo -e "${YELLOW}Using default configuration (claude, codex, gemini)${NC}" >&2
-        echo "claude|claude -p|🧠|CYAN"
-        echo "codex|codex exec|🤖|BLUE"
-        echo "gemini|gemini|💎|GREEN"
-        return
-    fi
-
-    # Extract members using awk (macOS/BSD compatible)
-    awk '
-    /^  members:/ { in_members=1; next }
-    /^  [a-z]/ && in_members { in_members=0 }
-    in_members && /- name:/ {
-        name=$3
-        gsub(/"/, "", name)
-    }
-    in_members && /command:/ {
-        cmd = $0
-        sub(/.*command: *"?/, "", cmd)
-        sub(/".*$/, "", cmd)
-    }
-    in_members && /emoji:/ {
-        emoji = $2
-        gsub(/"/, "", emoji)
-    }
-    in_members && /color:/ {
-        color = $2
-        gsub(/"/, "", color)
-        if (name && cmd) {
-            print name "|" cmd "|" emoji "|" color
-            name=""; cmd=""; emoji=""; color=""
-        }
-    }
-    ' "$CONFIG_FILE"
-}
-
-parse_chairman_role() {
-    if [ ! -f "$CONFIG_FILE" ]; then
-        echo "auto"
-        return
-    fi
-
-    awk '
-    /^  chairman:/ { in_chair=1; next }
-    /^  [a-z]/ && in_chair { in_chair=0 }
-    in_chair && /^    (role|name):/ {
-        val=$2
-        gsub(/"/, "", val)
-        print val
-        exit
-    }
-    ' "$CONFIG_FILE"
-}
-
-parse_chairman_command() {
-    if [ ! -f "$CONFIG_FILE" ]; then
-        return
-    fi
-
-    awk '
-    /^  chairman:/ { in_chair=1; next }
-    /^  [a-z]/ && in_chair { in_chair=0 }
-    in_chair && /^    command:/ {
-        cmd=$0
-        sub(/.*command:[ \t]*/, "", cmd) # remove prefix
-        sub(/[ \t]*#.*/, "", cmd) # remove comment
-        sub(/[ \t]*$/, "", cmd) # trim trailing space
-        if (substr(cmd, 1, 1) == "\"" && substr(cmd, length(cmd), 1) == "\"") {
-            cmd = substr(cmd, 2, length(cmd)-2)
-        }
-        print cmd
-        exit
-    }
-    ' "$CONFIG_FILE"
-}
-
-parse_setting_bool() {
-    local key="$1"
-    local default="$2"
-
-    if [ ! -f "$CONFIG_FILE" ]; then
-        echo "$default"
-        return
-    fi
-
-    local value
-    value="$(
-        awk -v k="$key" '
-        /^  settings:/ { in_settings=1; next }
-        /^  [a-z]/ && in_settings { in_settings=0 }
-        in_settings && $1 == (k ":") {
-            val=$2
-            gsub(/"/, "", val)
-            print val
-            exit
-        }
-        ' "$CONFIG_FILE"
-    )"
-
-    if [ -z "$value" ]; then
-        echo "$default"
-    else
-        echo "$value"
-    fi
-}
-
-normalize_bool() {
-    case "$(echo "$1" | tr '[:upper:]' '[:lower:]')" in
-        1|true|yes|y|on) echo "true" ;;
-        0|false|no|n|off) echo "false" ;;
-        *) echo "" ;;
-    esac
-}
-
-resolve_auto_role() {
-    local role="$1"
-    local host="$2"
-    local role_lc
-    role_lc="$(echo "$role" | tr '[:upper:]' '[:lower:]')"
-    if [ "$role_lc" != "auto" ] && [ -n "$role_lc" ]; then
-        echo "$role_lc"
-        return
-    fi
-    case "$host" in
-        codex) echo "codex" ;;
-        claude) echo "claude" ;;
-        *) echo "claude" ;;
-    esac
-}
-
-infer_default_chairman_command() {
-    case "$1" in
-        codex) echo "codex exec" ;;
-        gemini) echo "gemini" ;;
-        *) echo "" ;;
-    esac
-}
-
-echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-echo -e "${CYAN}🏛️  Agent Council - Gathering Opinions${NC}"
-echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-echo ""
-echo -e "${YELLOW}📝 Question:${NC} $PROMPT"
-echo ""
-
-# Function to call an agent
-call_agent() {
-    local name="$1"
-    local command="$2"
-    local output_file="$TEMP_DIR/${name}.txt"
-    local color_code="$3"
-    local show_thinking="$4"
-
-    if [ "$show_thinking" = "true" ]; then
-        echo -e "${color_code}[$name]${NC} Thinking..." >&2
-    fi
-
-    # Extract the base command (first word)
-    local base_cmd=$(echo "$command" | awk '{print $1}')
-
-    if command -v "$base_cmd" &> /dev/null; then
-        # Execute the command with the prompt
-        eval "$command \"\$PROMPT\"" 2>/dev/null > "$output_file" || echo "Error calling $name" > "$output_file"
-    else
-        echo "$name CLI not installed (command: $base_cmd)" > "$output_file"
-    fi
-
-    if [ "$show_thinking" = "true" ]; then
-        echo -e "${GREEN}[$name]${NC} Done" >&2
-    fi
-}
-
-# Function to call chairman for synthesis
-call_chairman() {
-    local name="$1"
-    local command="$2"
-    local chairman_prompt="$3"
-    local output_file="$TEMP_DIR/__chairman.txt"
-
-    if [ -z "$command" ]; then
-        echo "Chairman command not configured" > "$output_file"
-        return
-    fi
-
-    local base_cmd
-    base_cmd=$(echo "$command" | awk '{print $1}')
-    if ! command -v "$base_cmd" &> /dev/null; then
-        echo "Chairman CLI not installed (command: $base_cmd)" > "$output_file"
-        return
-    fi
-
-    # Use a temp file to avoid shell quoting issues with long/multiline prompts
-    local prompt_file="$TEMP_DIR/__chairman_prompt.txt"
-    printf "%s" "$chairman_prompt" > "$prompt_file"
-
-    # Most CLIs accept a prompt arg; codex exec also supports stdin via "-" but we keep it generic here.
-    # Read the prompt file into a variable so we can reuse the same execution pattern as members.
-    # Read the prompt file into a local variable to avoid modifying the global PROMPT variable.
-    local chairman_prompt_for_eval
-    chairman_prompt_for_eval="$(cat "$prompt_file")"
-    eval "$command \"\$chairman_prompt_for_eval\"" 2>/dev/null > "$output_file" || echo "Error calling chairman ($name)" > "$output_file"
-}
-
-# Resolve chairman + settings
-HOST="$(detect_host)"
-CHAIRMAN_ROLE_RAW="${CHAIRMAN_OVERRIDE:-$(parse_chairman_role)}"
-CHAIRMAN_ROLE="$(resolve_auto_role "${CHAIRMAN_ROLE_RAW:-auto}" "$HOST")"
-CHAIRMAN_COMMAND="${CHAIRMAN_COMMAND_OVERRIDE:-$(parse_chairman_command)}"
-
-EXCLUDE_CHAIRMAN_FROM_MEMBERS_RAW="${EXCLUDE_CHAIRMAN_OVERRIDE:-$(parse_setting_bool "exclude_chairman_from_members" "true")}"
-EXCLUDE_CHAIRMAN_FROM_MEMBERS="$(normalize_bool "$EXCLUDE_CHAIRMAN_FROM_MEMBERS_RAW")"
-if [ -z "$EXCLUDE_CHAIRMAN_FROM_MEMBERS" ]; then
-    EXCLUDE_CHAIRMAN_FROM_MEMBERS="true"
-fi
-
-SHOW_THINKING_RAW="$(parse_setting_bool "show_thinking" "true")"
-SHOW_THINKING="$(normalize_bool "$SHOW_THINKING_RAW")"
-if [ -z "$SHOW_THINKING" ]; then
-    SHOW_THINKING="true"
-fi
-
-PARALLEL_RAW="$(parse_setting_bool "parallel" "true")"
-PARALLEL="$(normalize_bool "$PARALLEL_RAW")"
-if [ -z "$PARALLEL" ]; then
-    PARALLEL="true"
-fi
-
-SYNTHESIZE_SETTING_RAW="$(parse_setting_bool "synthesize" "")"
-SYNTHESIZE_SETTING="$(normalize_bool "$SYNTHESIZE_SETTING_RAW")"
-if [ -n "$SYNTHESIZE_OVERRIDE" ]; then
-    SYNTHESIZE="$SYNTHESIZE_OVERRIDE"
-elif [ -n "$SYNTHESIZE_SETTING" ]; then
-    SYNTHESIZE="$SYNTHESIZE_SETTING"
-elif [ -n "$CHAIRMAN_COMMAND" ]; then
-    SYNTHESIZE="true"
-else
-    SYNTHESIZE="false"
-fi
-
-if [ "$SYNTHESIZE" = "true" ] && [ -z "$CHAIRMAN_COMMAND" ]; then
-    CHAIRMAN_COMMAND="$(infer_default_chairman_command "$CHAIRMAN_ROLE")"
-fi
-
-# Stage 1: Collect members and call in parallel
-echo -e "${YELLOW}Stage 1: Collecting opinions from council members...${NC}"
-echo ""
-
-# Read members and start parallel calls
-declare -a PIDS
-declare -a MEMBERS
-declare -a SKIPPED
-
-while IFS='|' read -r name cmd emoji color; do
-    [ -z "$name" ] && continue
-    if [ "$EXCLUDE_CHAIRMAN_FROM_MEMBERS" = "true" ] && [ "$(echo "$name" | tr '[:upper:]' '[:lower:]')" = "$CHAIRMAN_ROLE" ]; then
-        SKIPPED+=("$name")
-        continue
-    fi
-    MEMBERS+=("$name|$emoji|$color")
-    color_code=$(get_color_code "$color")
-    if [ "$PARALLEL" = "true" ]; then
-        call_agent "$name" "$cmd" "$color_code" "$SHOW_THINKING" &
-        PIDS+=($!)
-    else
-        call_agent "$name" "$cmd" "$color_code" "$SHOW_THINKING"
-    fi
-done < <(parse_members)
-
-# Wait for all agents
-if [ "$PARALLEL" = "true" ]; then
-    for pid in "${PIDS[@]}"; do
-        wait "$pid" 2>/dev/null || true
-    done
-fi
-
-echo ""
-if [ ${#SKIPPED[@]} -gt 0 ]; then
-    echo -e "${YELLOW}ⓘ Skipped member(s) because they are set as Chairman:${NC} ${SKIPPED[*]}"
-    echo ""
-fi
-echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-echo -e "${CYAN}Stage 2: Council Opinions${NC}"
-echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-echo ""
-
-# Display each member's response
-for member_info in "${MEMBERS[@]}"; do
-    IFS='|' read -r name emoji color <<< "$member_info"
-    color_code=$(get_color_code "$color")
-    output_file="$TEMP_DIR/${name}.txt"
-
-    echo -e "${color_code}┌─────────────────────────────────────────────────────────┐${NC}"
-    echo -e "${color_code}│ ${emoji} ${name}${NC}"
-    echo -e "${color_code}└─────────────────────────────────────────────────────────┘${NC}"
-
-    if [ -f "$output_file" ]; then
-        cat "$output_file"
-    else
-        echo "No response"
-    fi
-    echo ""
-done
-
-echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-if [ "$SYNTHESIZE" = "true" ] && [ -n "$CHAIRMAN_COMMAND" ]; then
-    echo -e "${CYAN}Stage 3: Chairman Synthesis (via CLI)${NC}"
-    echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-    echo ""
-
-    CHAIRMAN_PROMPT="You are the Chairman of an AI council."
-    CHAIRMAN_PROMPT+=$'\n\n'"User question:"
-    CHAIRMAN_PROMPT+=$'\n'"$PROMPT"
-    CHAIRMAN_PROMPT+=$'\n\n'"Council member opinions:"
-    for member_info in "${MEMBERS[@]}"; do
-        IFS='|' read -r name emoji color <<< "$member_info"
-        output_file="$TEMP_DIR/${name}.txt"
-        CHAIRMAN_PROMPT+=$'\n\n'"[${name}]"
-        if [ -f "$output_file" ]; then
-            CHAIRMAN_PROMPT+=$'\n'"$(cat "$output_file")"
-        else
-            CHAIRMAN_PROMPT+=$'\n'"No response"
-        fi
-    done
-    CHAIRMAN_PROMPT+=$'\n\n'"Please synthesize a final recommendation by:"
-    CHAIRMAN_PROMPT+=$'\n'"- Calling out common ground and disagreements"
-    CHAIRMAN_PROMPT+=$'\n'"- Providing a clear final answer"
-    CHAIRMAN_PROMPT+=$'\n'"- Responding in the same language as the user question"
-
-    call_chairman "$CHAIRMAN_ROLE" "$CHAIRMAN_COMMAND" "$CHAIRMAN_PROMPT"
-
-    output_file="$TEMP_DIR/__chairman.txt"
-    color_code=$(get_color_code "YELLOW")
-    echo -e "${color_code}┌─────────────────────────────────────────────────────────┐${NC}"
-    echo -e "${color_code}│ 🪑 chairman (${CHAIRMAN_ROLE})${NC}"
-    echo -e "${color_code}└─────────────────────────────────────────────────────────┘${NC}"
-    if [ -f "$output_file" ]; then
-        cat "$output_file"
-    else
-        echo "No response"
-    fi
-    echo ""
-else
-    echo -e "${CYAN}Stage 3: ${CHAIRMAN_ROLE} (Chairman) will synthesize above opinions (external)${NC}"
-    echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-fi
-
-# Cleanup
-rm -rf "$TEMP_DIR"
+"$JOB_SCRIPT" results "$JOB_DIR"
+"$JOB_SCRIPT" clean "$JOB_DIR" >/dev/null


### PR DESCRIPTION
This pull request introduces major improvements to the Agent Council skill, focusing on robust job management, improved documentation for both English and Korean users, and enhanced integration guidance for Codex and Claude host agents. The most significant changes include the addition of a new job worker implementation in Node.js, a Bash wrapper for job execution, and comprehensive updates to documentation to clarify job mode usage, host integration, and requirements.

**Job Execution Infrastructure:**

* Added `council-job-worker.js`, a Node.js script that runs individual council member jobs with timeout, status, and output/error tracking, improving reliability and scriptability of parallel agent execution.
* Added `council-job.sh`, a Bash wrapper that ensures Node.js is present and delegates to the Node.js job runner, providing a user-friendly entry point for job mode.

**Documentation and Integration Guidance:**

* Expanded English and Korean `README.md` files with detailed instructions for job mode execution, progress tracking, troubleshooting (e.g., Node.js requirement, runtime errors), and integration tips for Codex/Claude tool UIs, including checklist/plan UI update strategies. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R42) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R73-R74) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L140-R166) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L170-R195) [[5]](diffhunk://#diff-86fa6921bcebf260d55d8a3742c1b513bd78f4ea18366db989b5a03c68c563aeR42) [[6]](diffhunk://#diff-86fa6921bcebf260d55d8a3742c1b513bd78f4ea18366db989b5a03c68c563aeR73-R74) [[7]](diffhunk://#diff-86fa6921bcebf260d55d8a3742c1b513bd78f4ea18366db989b5a03c68c563aeL140-R166) [[8]](diffhunk://#diff-86fa6921bcebf260d55d8a3742c1b513bd78f4ea18366db989b5a03c68c563aeL170-R195)
* Updated `SKILL.md` with explicit job mode usage examples, host agent integration patterns, and recommendations for updating native checklist UIs using `wait` and plan/todo update calls. [[1]](diffhunk://#diff-5b8a953cfb9a5fcaf38e979d1113d2a0897c1617c9d5a792b891fefeba8afab6R40-R92) [[2]](diffhunk://#diff-5b8a953cfb9a5fcaf38e979d1113d2a0897c1617c9d5a792b891fefeba8afab6R133)

**Host Agent Instructions:**

* Added `AGENTS.md` and `CLAUDE.md` with clear, step-by-step instructions for integrating Agent Council into Codex and Claude host agents, emphasizing correct checklist/plan update patterns and UI behaviors. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R1-R7) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R1-R8)

**Configuration and Requirements:**

* Updated `council.config.yaml` to clarify timeout semantics and remove unused parallelism and show_thinking options, reflecting the new job management approach.
* Clarified Node.js requirement in documentation and installation instructions, ensuring users are aware of this dependency for plugin and job-based operation.

**File Structure:**

* Revised documentation to reflect the expanded file structure, including new job runner scripts and worker files in the `scripts/` directory. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L170-R195) [[2]](diffhunk://#diff-86fa6921bcebf260d55d8a3742c1b513bd78f4ea18366db989b5a03c68c563aeL170-R195)

These changes collectively make Agent Council more robust, easier to integrate into host agents, and clearer to install and operate for both English and Korean users.

## This is the preveiw of result
<img width="1152" height="945" alt="Screenshot 2025-12-17 at 5 35 54 PM" src="https://github.com/user-attachments/assets/c573fc0b-7f27-4ffa-ba61-8a6cf7d5b14c" />
<img width="1152" height="945" alt="Screenshot 2025-12-17 at 5 49 16 PM" src="https://github.com/user-attachments/assets/ad214607-ffd9-4eb9-8689-2a5da7f53f7b" />
<img width="1152" height="945" alt="Screenshot 2025-12-17 at 5 47 47 PM" src="https://github.com/user-attachments/assets/143f187e-a2ac-486c-8b39-134dbd2e4f38" />
