### PR TITLE
docs: align skill docs with spec

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -58,7 +58,7 @@ npx github:team-attention/agent-council --target claude
 npx github:team-attention/agent-council --target both
 ```
 
-생성되는 `council.config.yaml`은 감지된 멤버 CLI(claude/codex/gemini 등)만 활성화하며, 설치 타깃(호스트)은 members에 포함되지 않도록 처리합니다.
+생성되는 `council.config.yaml`은 감지된 멤버 CLI(claude/codex/gemini 등)만 포함하며, 설치 타깃(호스트)은 members에 포함되지 않도록 처리합니다. 이 필터링은 **초기 생성 시점에만** 적용되며, 이후 편집 내용은 자동으로 정리되지 않습니다.
 
 ### 방법 B: Claude Code 플러그인으로 설치 (Claude Code 전용)
 
@@ -74,7 +74,7 @@ npx github:team-attention/agent-council --target both
 
 ### 2. Agent CLI 설치
 
-Council 멤버로 쓰고 싶은 CLI를 설치하세요(템플릿 기본 포함: `claude`, `codex`, `gemini`):
+`council.config.yaml`의 `council.members`에 적힌 CLI를 설치하세요(템플릿 기본 포함: `claude`, `codex`, `gemini`):
 
 ```bash
 # Anthropic Claude Code
@@ -87,11 +87,11 @@ Council 멤버로 쓰고 싶은 CLI를 설치하세요(템플릿 기본 포함: 
 # https://github.com/google-gemini/gemini-cli
 ```
 
-설치 확인:
+설치 확인(멤버별):
 ```bash
-claude --version
-codex --version
-gemini --version
+command -v claude
+command -v codex
+command -v gemini
 ```
 
 ### 3. Council 멤버 설정 (선택사항)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ npx github:team-attention/agent-council --target claude
 npx github:team-attention/agent-council --target both
 ```
 
-The generated `council.config.yaml` enables only detected member CLIs (e.g. `claude`, `codex`, `gemini`) and avoids adding the host target as a member.
+The generated `council.config.yaml` includes only detected member CLIs (e.g. `claude`, `codex`, `gemini`) and avoids adding the host target as a member. This filtering happens only at initial generation; later edits will not auto-remove missing CLIs.
 
 ### Option B: Install via Claude Code Plugin (Claude Code only)
 
@@ -74,7 +74,7 @@ Note (Plugin installs): **Agent Council requires Node.js**, and Claude Code plug
 
 ### 2. Install Agent CLIs
 
-Install the CLIs you want to use as council members (template includes `claude`, `codex`, `gemini`):
+Install the CLIs listed under `council.members` in your `council.config.yaml` (template includes `claude`, `codex`, `gemini`):
 
 ```bash
 # Anthropic Claude Code
@@ -87,11 +87,11 @@ Install the CLIs you want to use as council members (template includes `claude`,
 # https://github.com/google-gemini/gemini-cli
 ```
 
-Verify installation:
+Verify each member CLI:
 ```bash
-claude --version
-codex --version
-gemini --version
+command -v claude
+command -v codex
+command -v gemini
 ```
 
 ### 3. Configure Council Members (Optional)

--- a/council.config.yaml
+++ b/council.config.yaml
@@ -1,5 +1,7 @@
 # Agent Council Configuration
-# Add or remove council members as needed
+# Add or remove council members as needed.
+# Note: the installer filters members to detected CLIs only on initial generation.
+# After that, missing CLIs are not auto-removed and will report `missing_cli` at runtime.
 
 council:
   # Council members configuration

--- a/skills/agent-council/SKILL.md
+++ b/skills/agent-council/SKILL.md
@@ -1,179 +1,34 @@
 ---
 name: agent-council
-description: Collect and synthesize opinions from multiple AI Agents. Use when users say "summon the council", "ask other AIs", or want multiple AI perspectives on a question.
+description: Collect and synthesize opinions from multiple AI agents. Use when users say "summon the council", "ask other AIs", or want multiple AI perspectives on a question.
 ---
 
 # Agent Council
 
-> Collect and synthesize opinions from multiple AI Agents
-> Inspired by [Karpathy's LLM Council](https://github.com/karpathy/llm-council)
-
-## Overview
-
-Agent Council gathers opinions from multiple AI Agents (Codex, Gemini, etc.) when facing difficult questions or decisions. A configurable Chairman then synthesizes the final response (default: `role: auto`, meaning the host agent you’re using).
-
-## Trigger Conditions
-
-This skill activates when:
-- "Let's hear opinions from other AIs"
-- "Summon the council"
-- "Review this from multiple perspectives"
-- "Ask codex and gemini for their opinions"
-- "council"
-- "$agent-council"
-
-## 3-Stage Process (LLM Council Method)
-
-### Stage 1: Initial Opinions
-Send the same question to each council member to collect initial opinions
-
-### Stage 2: Response Collection
-Collect and display each Agent's response to the user
-
-### Stage 3: Chairman Synthesis
-The Chairman synthesizes all responses and presents the final opinion (usually handled by the host agent; optionally can be executed inside `council.sh` via `chairman.command`)
+Collect multiple AI opinions and synthesize one answer.
 
 ## Usage
 
-### Direct Script Execution
+Run a job and collect results:
 
 ```bash
 JOB_DIR=$(./skills/agent-council/scripts/council.sh start "your question here")
-./skills/agent-council/scripts/council.sh status --text "$JOB_DIR"
-./skills/agent-council/scripts/council.sh status --checklist "$JOB_DIR"
-./skills/agent-council/scripts/council.sh wait "$JOB_DIR" # returns JSON + persists a cursor for blocking waits
+./skills/agent-council/scripts/council.sh wait "$JOB_DIR"
 ./skills/agent-council/scripts/council.sh results "$JOB_DIR"
 ./skills/agent-council/scripts/council.sh clean "$JOB_DIR"
 ```
 
-One-shot (runs job → waits → prints results → cleans):
+One-shot:
 
 ```bash
 ./skills/agent-council/scripts/council.sh "your question here"
 ```
 
-Note:
-- In host-agent tool UIs (Codex CLI / Claude Code), one-shot does **not** block (so the host can update native plan/todo UIs). It returns a single `wait` JSON payload, and the host should continue with `wait` → native UI update → `results` → `clean`.
+## References
 
-### Execution via Host Agent (progress, no tool-cell spam)
-
-When using this skill inside a host agent (Codex CLI / Claude Code), some UIs do not stream long-running tool output. Prefer **job mode + `wait`** so the host agent can update a native checklist (e.g. `update_plan`) with only a few tool calls.
-
-```bash
-JOB_DIR=$(./skills/agent-council/scripts/council.sh start "your question here")
-./skills/agent-council/scripts/council.sh wait "$JOB_DIR" # returns immediately (seeds cursor + JSON payload)
-# Host agent MUST now call its native checklist tool:
-# - Codex CLI: update_plan(.ui.codex.update_plan.plan)
-# - Claude Code: TodoWrite(.ui.claude.todo_write.todos)
-./skills/agent-council/scripts/council.sh wait "$JOB_DIR" # blocks until meaningful progress
-# Host agent updates the native checklist again after each wait return
-./skills/agent-council/scripts/council.sh results "$JOB_DIR"
-./skills/agent-council/scripts/council.sh clean "$JOB_DIR"
-```
-
-Notes:
-- `wait` prints JSON, remembers its cursor in `<jobDir>/.wait_cursor`, and returns only when progress meaningfully changes.
-- Default `wait` auto-batches to a small number of updates (typically ~5–10 total; `--bucket 1` for every completion).
-- One-shot prints progress in a normal terminal, but may not render live inside some host agent tool UIs.
-
-**Recommended host-agent checklist strategy (`update_plan`):**
-- `wait` JSON includes a pre-built council checklist you can feed into native UIs:
-  - Codex CLI: `update_plan` input at `.ui.codex.update_plan.plan`
-  - Claude Code: `TodoWrite` input at `.ui.claude.todo_write.todos`
-- IMPORTANT: The native checklist UI can only be updated by the host agent. Shell scripts cannot force it to appear.
-- IMPORTANT (Codex): Don’t run a blocking `wait` call before calling `update_plan` at least once, or the Plan UI won’t show until the wait returns.
-- Preserve any existing items as-is, and append the `[Council]` section (so the user’s TODO list doesn’t “disappear”).
-- The default council checklist is intentionally small (`N + 2` items):
-  - `[Council] Prompt dispatch`
-  - One line per member: `[Council] Ask <member>` (checkbox marks completion)
-  - `[Council] Synthesize`
-  - (With the default config, `N` is usually 2 because the chairman is excluded, so you’ll typically see 4 items total.)
-- The checklist keeps **exactly one** `in_progress` item while work remains (dispatch → one running member → synthesize) so Codex’s Plan UI stays visible; keep at most one `in_progress` at a time.
-- Don’t run a long `while true` loop in a single shell tool call; update the UI only after each `wait` return (auto-batched), then restore the original list (or remove the `[Council]` section) when finished.
-
-## Examples
-
-### Technical Decision Making
-
-```
-User: "React vs Vue - which fits this project better? Summon the council"
-
-Host agent:
-1. Execute council.sh to collect opinions from configured members (e.g., Codex, Gemini)
-2. Organize each Agent's perspective
-3. Recommend based on project context
-```
-
-### Architecture Review
-
-```
-User: "Let's hear other AIs' opinions on this design"
-
-Host agent:
-1. Summarize current design and query the council
-2. Collect feedback from each Agent
-3. Analyze commonalities/differences and provide synthesis
-```
-
-## Council Members
-
-Council members are configured in `council.config.yaml`. The installer enables only detected CLIs and (by default) excludes the host chairman from members.
-
-| Agent | CLI Command | Characteristics |
-|-------|-------------|-----------------|
-| Claude Code | `claude -p` | Thoughtful, structured reasoning |
-| OpenAI Codex | `codex exec` | Code-focused, pragmatic approach |
-| Google Gemini | `gemini` | Broad knowledge, diverse perspectives |
-| Chairman (auto) | - | Synthesis and final judgment (by your host agent) |
-
-## Requirements
-
-- Each configured CLI must be installed and authenticated
-- Template includes: Claude CLI, OpenAI Codex CLI, Google Gemini CLI
-- Requires Node.js (plugins can’t bundle or auto-install it)
-
-### Verify Installation
-
-```bash
-claude --version
-codex --version
-gemini --version
-```
-
-## Configuration
-
-Edit `council.config.yaml` to customize council members:
-
-```yaml
-council:
-  chairman:
-    role: "auto"
-  members:
-    - name: claude
-      command: "claude -p"
-      emoji: "🧠"
-      color: "CYAN"
-    - name: codex
-      command: "codex exec"
-      emoji: "🤖"
-      color: "BLUE"
-    - name: gemini
-      command: "gemini"
-      emoji: "💎"
-      color: "GREEN"
-```
-
-## File Structure
-
-```
-skills/agent-council/
-├── SKILL.md              # This document
-└── scripts/
-    └── council.sh        # Council execution script
-```
-
-## Notes
-
-- Costs and auth depend on each Agent CLI
-- Response time depends on the slowest Agent
-- Do not share sensitive information with the council
+- `references/overview.md` — workflow and background.
+- `references/examples.md` — usage examples.
+- `references/config.md` — member configuration.
+- `references/requirements.md` — dependencies and CLI checks.
+- `references/host-ui.md` — host UI checklist guidance.
+- `references/safety.md` — safety notes.

--- a/skills/agent-council/references/config.md
+++ b/skills/agent-council/references/config.md
@@ -9,15 +9,15 @@ council:
   members:
     - name: claude
       command: "claude -p"
-      emoji: ":brain:"
+      emoji: "🧠"
       color: "CYAN"
     - name: codex
       command: "codex exec"
-      emoji: ":robot:"
+      emoji: "🤖"
       color: "BLUE"
     - name: gemini
       command: "gemini"
-      emoji: ":gem:"
+      emoji: "💎"
       color: "GREEN"
 ```
 

--- a/skills/agent-council/references/config.md
+++ b/skills/agent-council/references/config.md
@@ -1,0 +1,29 @@
+# Configure members
+
+Edit `council.config.yaml` to set chairman and members:
+
+```yaml
+council:
+  chairman:
+    role: "auto"
+  members:
+    - name: claude
+      command: "claude -p"
+      emoji: ":brain:"
+      color: "CYAN"
+    - name: codex
+      command: "codex exec"
+      emoji: ":robot:"
+      color: "BLUE"
+    - name: gemini
+      command: "gemini"
+      emoji: ":gem:"
+      color: "GREEN"
+```
+
+Add custom members by appending entries to `members`:
+
+- Use a stable `name` (lowercase, short).
+- Set `command` to a runnable CLI invocation.
+- Provide `emoji` and `color` for readability (optional but recommended).
+- Note that the installer filters members to detected CLIs only when it first generates `council.config.yaml`. After that, missing CLIs are not auto-removed and will report `missing_cli` at runtime; remove unavailable members or install the CLI before running.

--- a/skills/agent-council/references/examples.md
+++ b/skills/agent-council/references/examples.md
@@ -1,0 +1,25 @@
+# Examples
+
+## Technical decision
+
+Prompt:
+```
+React vs Vue - which fits this project better? Summon the council
+```
+
+Steps:
+1. Run `council.sh` to collect opinions from configured members.
+2. Organize member perspectives.
+3. Recommend based on project context.
+
+## Architecture review
+
+Prompt:
+```
+Let's hear other AIs' opinions on this design
+```
+
+Steps:
+1. Summarize the design and query the council.
+2. Collect feedback from each member.
+3. Analyze commonalities and synthesize.

--- a/skills/agent-council/references/host-ui.md
+++ b/skills/agent-council/references/host-ui.md
@@ -1,0 +1,18 @@
+# Host UI Checklist Guidance
+
+Use these steps only when a host agent UI supports native checklist updates.
+
+## Checklist flow
+
+1. Run `council.sh wait` once to seed the cursor and get the JSON payload.
+2. Update the host's native checklist UI using the payload (if provided).
+3. Repeat `wait` until progress changes, then update the UI again.
+4. Finish with `results` and `clean`.
+
+## Behavior notes
+
+- Do not run a blocking wait before the first checklist update, or the Plan UI may not appear.
+- Keep exactly one in_progress item while work remains.
+- Preserve existing checklist items and append the [Council] section.
+- Avoid a long while loop in a single tool call; update after each wait return.
+- Use `--bucket 1` for per-member updates when needed.

--- a/skills/agent-council/references/overview.md
+++ b/skills/agent-council/references/overview.md
@@ -1,0 +1,12 @@
+# Overview
+
+- Gather responses from configured member CLIs.
+- Let the chairman synthesize the final response (default: `role: auto`, current agent).
+- Configure members in `council.config.yaml`; exclude the chairman from members by default.
+- Reference [Karpathy's LLM Council](https://github.com/karpathy/llm-council) for inspiration.
+
+## Workflow (3 stages)
+
+1. Send the same prompt to each member.
+2. Collect and surface member responses.
+3. Synthesize the final answer as chairman; optionally run the chairman inside `council.sh` via `chairman.command`.

--- a/skills/agent-council/references/requirements.md
+++ b/skills/agent-council/references/requirements.md
@@ -1,0 +1,6 @@
+# Requirements
+
+- Install and authenticate the CLIs listed under `council.members` in `council.config.yaml`.
+- Note that the installer filters members to detected CLIs only on initial config generation; afterward, missing CLIs show as `missing_cli` in status output.
+- Install Node.js (plugins cannot bundle or auto-install it).
+- Verify each member’s base command exists (for example, `command -v <binary>` or `<binary> --version`).

--- a/skills/agent-council/references/safety.md
+++ b/skills/agent-council/references/safety.md
@@ -1,0 +1,3 @@
+# Safety
+
+- Do not share sensitive information with the council.


### PR DESCRIPTION
This pull request updates the documentation and configuration for the Agent Council skill to clarify installation, member management, and usage, while splitting detailed guidance into focused reference files for easier navigation. The main `SKILL.md` is simplified, with specifics about workflow, configuration, examples, requirements, host UI integration, and safety moved to new reference documents. The installation and verification instructions are also clarified in both English and Korean READMEs.

**Documentation and Usage Guidance Improvements:**

- The main `SKILL.md` is rewritten to be concise and now points to new reference files for detailed instructions, configuration, examples, requirements, host UI integration, and safety notes. This makes the documentation easier to follow and maintain. [[1]](diffhunk://#diff-5b8a953cfb9a5fcaf38e979d1113d2a0897c1617c9d5a792b891fefeba8afab6L3-R34) [[2]](diffhunk://#diff-ab74110876f09cb2f5ad1fef36203c82d57f4f53ca6887120703c880db93dd58R1-R29) [[3]](diffhunk://#diff-d7a6fd5627a36a1938d33235e5335d82642dc547aab438beb64600afcf4ffca3R1-R25) [[4]](diffhunk://#diff-c6a332186169c6e621b8915c813f9c6bbabedd8ebe12377b0139171873a1856aR1-R18) [[5]](diffhunk://#diff-9003dcbde9ba2aebfc1b2c1b8c021df11d053693cddfef41352b13d75579d9a1R1-R12) [[6]](diffhunk://#diff-9afa615c8140e98b4eead9422fcdbb62b64abfe0837f9f55ed0effd0fee44ab2R1-R6) [[7]](diffhunk://#diff-05d03f08972f1d9635a2ff889353bf2a7871b36c1533ae8f0ed6dbad2af158a8R1-R3)

- The English and Korean `README.md` files clarify that only detected member CLIs are included in `council.config.yaml` at initial generation, and that later edits do not automatically remove missing CLIs. Installation and verification instructions now direct users to check for each CLI listed in `council.members` using `command -v <cli>`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L61-R61) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L77-R77) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L90-R94) [[4]](diffhunk://#diff-86fa6921bcebf260d55d8a3742c1b513bd78f4ea18366db989b5a03c68c563aeL61-R61) [[5]](diffhunk://#diff-86fa6921bcebf260d55d8a3742c1b513bd78f4ea18366db989b5a03c68c563aeL77-R77) [[6]](diffhunk://#diff-86fa6921bcebf260d55d8a3742c1b513bd78f4ea18366db989b5a03c68c563aeL90-R94)

**Configuration and Runtime Behavior Clarifications:**

- The `council.config.yaml` file and new configuration reference clarify that the installer only filters members to detected CLIs at initial generation. Afterward, missing CLIs will report `missing_cli` at runtime and are not auto-removed. [[1]](diffhunk://#diff-7e4704eca8b49c8debfb0b852283f1462733dd791f7ba441cb2050295750d509L2-R4) [[2]](diffhunk://#diff-ab74110876f09cb2f5ad1fef36203c82d57f4f53ca6887120703c880db93dd58R1-R29)

**Reference Material Additions:**

- Adds new reference files for:
  - Overview and workflow (`references/overview.md`)
  - Configuration (`references/config.md`)
  - Usage examples (`references/examples.md`)
  - Requirements and CLI checks (`references/requirements.md`)
  - Host UI checklist integration (`references/host-ui.md`)
  - Safety notes (`references/safety.md`)